### PR TITLE
Fix to triggers breaking changes TP2

### DIFF
--- a/testdata/triggers/cron/eventlistener.yaml
+++ b/testdata/triggers/cron/eventlistener.yaml
@@ -7,6 +7,6 @@ spec:
   triggers:
     - name: cron-trig
       bindings:
-      - name: cron-binding
+      - ref: cron-binding
       template:
         name: pipeline-template


### PR DESCRIPTION
- API Breaking change now
```
triggers event listeners, binding reference payload need to be changed
From:
bindings:
      - name: cron-binding
To:
bindings:
      - ref: cron-binding
```