### PR TITLE
Revert TLS default eventlistener behaviour

### DIFF
--- a/pkg/oc/oc.go
+++ b/pkg/oc/oc.go
@@ -36,6 +36,6 @@ func CreateSecretWithSecretToken(secretname, namespace string) {
 	log.Printf("output: %s\n", cmd.MustSucceed("oc", "create", "secret", "generic", secretname, "--from-literal=secretToken="+os.Getenv("SECRET_TOKEN"), "-n", namespace).Stdout())
 }
 
-func DisableDefaultTLSConfigForEventlisteners(namespace string) {
-	log.Printf("output: %s\n", cmd.MustSucceed("oc", "label", "namespace", namespace, "operator.tekton.dev/disable-annotation=disabled").Stdout())
+func EnableTLSConfigForEventlisteners(namespace string) {
+	log.Printf("output: %s\n", cmd.MustSucceed("oc", "label", "namespace", namespace, "operator.tekton.dev/enable-annotation=enabled").Stdout())
 }

--- a/specs/triggers/cron.spec
+++ b/specs/triggers/cron.spec
@@ -9,7 +9,6 @@ Tags: e2e,triggers
 This scenario helps you to Trigger pipelineRun, using a k8s CronJob, to implement a basic cron trigger that runs every minute
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                 |
     |----|---------------------------------------------|

--- a/specs/triggers/eventlistener.spec
+++ b/specs/triggers/eventlistener.spec
@@ -117,6 +117,7 @@ This scenario tests the creation of eventLister with TLS enabled, listens to eve
 openshift-pipeline Resources defined under triggers-template, which helps you to deploy example app
 
 Steps:
+  * Enable TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                                        |
     |----|--------------------------------------------------------------------|
@@ -140,7 +141,6 @@ This scenario tests the creation of eventLister with embedded triggerbinding spe
 openshift-pipeline Resources defined under triggers-template, which helps you to deploy example app
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                                        |
     |----|--------------------------------------------------------------------|
@@ -164,7 +164,6 @@ This scenario tests the creation of embedded triggertemplate spec, listens to ev
 openshift-pipeline Resources defined under triggers-template, which helps you to deploy example app
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                                       |
     |----|-------------------------------------------------------------------|
@@ -187,7 +186,6 @@ This scenario tests the creation of eventLister with gitlab interceptor, listens
 openshift-pipeline Resources defined under triggers-template, to deploy example app
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                      |
     |----|--------------------------------------------------|
@@ -209,7 +207,6 @@ This scenario tests the creation of eventLister with bitbucket interceptor, list
 openshift-pipeline Resources defined under triggers-template
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                                        |
     |----|--------------------------------------------------------------------|
@@ -231,7 +228,6 @@ This scenario tests Github `push` event via CTB, on each event it creates/trigge
 openshift-pipeline Resources defined under triggers-template
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                                      |
     |----|------------------------------------------------------------------|
@@ -254,7 +250,6 @@ This scenario tests Github `pull_request` event via CTB, on each event it create
 openshift-pipeline Resources defined under triggers-template
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                                    |
     |----|----------------------------------------------------------------|
@@ -277,7 +272,6 @@ This scenario tests Github `issue_comment` event via CTB, on each event it creat
 openshift-pipeline Resources defined under triggers-template
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                                           |
     |----|-----------------------------------------------------------------------|
@@ -300,7 +294,6 @@ This scenario tests the creation of Trigger resource which is combination of Tri
 openshift-pipeline Resources defined under triggers-template  
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                               |
     |----|-----------------------------------------------------------|

--- a/specs/triggers/v1alpha1.spec
+++ b/specs/triggers/v1alpha1.spec
@@ -7,7 +7,6 @@ Pre condition:
 Tags: e2e, triggers
 
 Steps:
-  * Disable default TLS config for eventlisteners
   * Create
     |S.NO|resource_dir                                 |
     |----|---------------------------------------------|

--- a/steps/cli/oc.go
+++ b/steps/cli/oc.go
@@ -14,8 +14,8 @@ var _ = gauge.Step("Create <table>", func(table *m.Table) {
 	}
 })
 
-var _ = gauge.Step("Disable default TLS config for eventlisteners", func() {
-	oc.DisableDefaultTLSConfigForEventlisteners(store.Namespace())
+var _ = gauge.Step("Enable TLS config for eventlisteners", func() {
+	oc.EnableTLSConfigForEventlisteners(store.Namespace())
 
 })
 


### PR DESCRIPTION
*  In this [pr](https://github.com/tektoncd/operator/pull/270), we decided not enable `TLS encryption` by  default.

To run tls tests.

Add below label so by default all communications are encrypted via `https`
```
oc label ns <namespace> operator.tekton.dev/enable-annotation=enabled
```

* Now RBAC should also revert back to `pipelines-anyuid` instead of `pipelines-restricted`