### PR TITLE
Triggers 1.5 cluster interceptor spec changes

### DIFF
--- a/specs/triggers/cron.spec
+++ b/specs/triggers/cron.spec
@@ -18,7 +18,7 @@ Steps:
     |S.NO|resource_dir                                 |
     |----|---------------------------------------------|
     |1   |testdata/triggers/cron/example-pipeline.yaml |
-    |2   |testdata/triggers/cron/tiggerbinding.yaml    |
+    |2   |testdata/triggers/cron/triggerbinding.yaml   |
     |3   |testdata/triggers/cron/triggertemplate.yaml  |
     |4   |testdata/triggers/cron/eventlistener.yaml    |
   * Expose Event listener "cron-listener"

--- a/testdata/triggers/bitbucket/bitbucket-eventlistener-interceptor.yaml
+++ b/testdata/triggers/bitbucket/bitbucket-eventlistener-interceptor.yaml
@@ -55,14 +55,20 @@ spec:
     serviceAccountName: pipeline
     triggers:
     - name: bitbucket-triggers
-      interceptors:
-        - bitbucket:
-            secretRef:
-                secretName: bitbucket-secret
-                secretKey: secretToken
-            eventTypes:
-                - repo:refs_changed
       bindings:
         - ref: bitbucket-binding
+      interceptors:
+        - name: verify-bitbucket-payload
+          params:
+            - name: secretRef
+              value:
+                secretKey: secretToken
+                secretName: bitbucket-secret
+            - name: eventTypes
+              value:
+                - 'repo:refs_changed'
+          ref:
+            kind: ClusterInterceptor
+            name: bitbucket
       template:
         ref: bitbucket-template

--- a/testdata/triggers/cron/triggerbinding.yaml
+++ b/testdata/triggers/cron/triggerbinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: cron-binding
+spec:
+  params:
+  - name: gitrevision
+    value: main
+  - name: gitrepositoryurl
+    value: https://github.com/tektoncd/triggers
+  - name: contenttype
+    value: $(header.Content-Type)

--- a/testdata/triggers/gitlab/gitlab-push-listener.yaml
+++ b/testdata/triggers/gitlab/gitlab-push-listener.yaml
@@ -55,12 +55,18 @@ spec:
   triggers:
     - name: gitlab-push-events-trigger
       interceptors:
-        - gitlab:
-            secretRef:
-              secretName: gitlab-secret
-              secretKey: secretToken
-            eventTypes:
-              - Push Hook  # Only push events
+        - name: verify-gitlab-payload
+          params:
+            - name: secretRef
+              value:
+                secretName: gitlab-secret
+                secretKey: secretToken
+            - name: eventTypes
+              value:
+                - 'Push Hook'
+          ref:
+            kind: ClusterInterceptor
+            name: gitlab   
       bindings:
         - ref: gitlab-push-binding
       template:

--- a/testdata/triggers/triggerbindings/cel-marshalJson.yaml
+++ b/testdata/triggers/triggerbindings/cel-marshalJson.yaml
@@ -7,10 +7,15 @@ spec:
   triggers:
     - name: cel-trig
       interceptors:
-        - cel:
-            overlays:
-            - key: marshaled_body
-              expression: "body.marshalJSON()"
+      - name: verify-cel-overlays
+        ref:
+          name: cel
+          kind: ClusterInterceptor
+        params:
+          - name: "overlays"
+            value:
+              - key: marshaled_body
+                expression: "body.marshalJSON()"
       bindings:
       - name: body
         value: $(extensions.marshaled_body)

--- a/testdata/triggers/triggersCRD/trigger.yaml
+++ b/testdata/triggers/triggersCRD/trigger.yaml
@@ -4,11 +4,17 @@ metadata:
   name: trigger
 spec:
   interceptors:
-    - cel:
-        filter: "header.match('X-GitHub-Event', 'pull_request')"
-        overlays:
-        - key: "truncated_sha"
-          expression: "body.pull_request.head.sha.truncate(7)"
+    - name: verify-cel-overlays-with-filter
+      ref:
+        name: cel
+        kind: ClusterInterceptor
+      params:
+        - name: "overlays"
+          value:
+            - key: filter
+              value: "header.match('X-GitHub-Event', 'pull_request')"
+            - key: truncated_sha
+              expression: "body.pull_request.head.sha.truncate(7)"
   bindings:
   - ref: github-pr-binding
   template:


### PR DESCRIPTION
* Updated Triggers spec to use latest spec changes specific to cluster Interceptor!
I see only one breaking change that is with feature flags need to set `disable-home-env-overwrite: 'false'` would help you run both previous and updated specs