### PR TITLE
Fixing ARCH extraction error

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,10 +135,9 @@ func initializeFlags() *EnvironmentFlags {
 		"Provide tknversion to download specified cli binary you'd like to use for these tests. By default `0.6.0` will be used.")
 
 	defaultClusterArch := os.Getenv("ARCH")
-	if defaultClusterArch != "" {
-		if strings.Contains(defaultClusterArch, "/") {
-			defaultClusterArch = strings.Split(defaultClusterArch, "/")[1]
-		}
+	if defaultClusterArch != ""  && strings.Contains(defaultClusterArch, "/") {
+		defaultClusterArch = strings.Split(defaultClusterArch, "/")[1]
+		
 	}
 	flag.StringVar(&f.ClusterArch, "clusterarch", defaultClusterArch,
 		"Provide the architecture of testing cluster. By default `amd64` will be used.")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,7 +136,9 @@ func initializeFlags() *EnvironmentFlags {
 
 	defaultClusterArch := os.Getenv("ARCH")
 	if defaultClusterArch != "" {
-		defaultClusterArch = strings.Split(defaultClusterArch, "/")[1]
+		if strings.Contains(defaultClusterArch, "/") {
+			defaultClusterArch = strings.Split(defaultClusterArch, "/")[1]
+		}
 	}
 	flag.StringVar(&f.ClusterArch, "clusterarch", defaultClusterArch,
 		"Provide the architecture of testing cluster. By default `amd64` will be used.")


### PR DESCRIPTION
The addon tests were not running if the value for the ARCH does not contain "/". Updated code to skip splitting the string if it does not contain "/"