### PR TITLE
Ignore errors if the namespace deletion fails

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -42,7 +42,7 @@ func NewClientSet() (*clients.Clients, string, func()) {
 	assert.FailOnError(err)
 	oc.CreateNewProject(ns)
 	return cs, ns, func() {
-		oc.DeleteProject(ns)
+		oc.DeleteProjectIgnoreErors(ns)
 	}
 }
 

--- a/pkg/oc/oc.go
+++ b/pkg/oc/oc.go
@@ -30,6 +30,10 @@ func DeleteProject(ns string) {
 	log.Printf("output: %s\n", cmd.MustSucceed("oc", "delete", "project", ns).Stdout())
 }
 
+func DeleteProjectIgnoreErors(ns string) {
+	log.Printf("output: %s\n", cmd.Run("oc", "delete", "project", ns).Stdout())
+}
+
 func LinkSecretToSA(secretname, sa, namespace string) {
 	log.Printf("output: %s\n", cmd.MustSucceed("oc", "secret", "link", "serviceaccount/"+sa, "secrets/"+secretname, "-n", namespace).Stdout())
 }


### PR DESCRIPTION
We create a new namespace for each test scenario and delete the namespace once after the test scenario execution gets completed. Sometimes the test scenario gets executed successfully but the test scenario will be marked as "Fail" if there is any failure in deletion of namespace. Hence, I created a new function which deletes the namespace and it does not expect command to get executed successfully