### PR TITLE
 Skipping deletion of namespace when a test fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20201125194554-85d881c3777e
-	github.com/getgauge-contrib/gauge-go v0.2.0
+	github.com/getgauge-contrib/gauge-go v0.3.1
 	github.com/google/go-cmp v0.5.7
 	github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7R
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
-github.com/getgauge-contrib/gauge-go v0.2.0 h1:UkqEXm+APHC2aswqC9cG9qwEuXNanId/hsOuGiiMx08=
-github.com/getgauge-contrib/gauge-go v0.2.0/go.mod h1:6/Aagmhzq0I878fDXqIkrnzvo3aaTuJ5upVhOQTGL48=
+github.com/getgauge-contrib/gauge-go v0.3.1 h1:MYlgeKSjlnwcxLE13WqZP4/t4utGhKr5UetguSEtj9A=
+github.com/getgauge-contrib/gauge-go v0.3.1/go.mod h1:6/Aagmhzq0I878fDXqIkrnzvo3aaTuJ5upVhOQTGL48=
 github.com/getgauge/common v0.0.0-20160906120419-fce5f398028f/go.mod h1:tHtGp+rvfECQYRDCNQX46uQTO6qHpdDrikX9ZkBjkSA=
 github.com/getgauge/common v0.0.0-20200824023809-24587c106922 h1:/KwwglTNoofndO0RhEPY750erewl4uAL+WbfN+nLkVs=
 github.com/getgauge/common v0.0.0-20200824023809-24587c106922/go.mod h1:e3V+gYeNMZt9gGaHqxwnVAwrewx6uauCqT+IE0vZhM8=

--- a/pkg/oc/oc.go
+++ b/pkg/oc/oc.go
@@ -8,8 +8,6 @@ import (
 	"github.com/getgauge-contrib/gauge-go/testsuit"
 	"github.com/openshift-pipelines/release-tests/pkg/cmd"
 	resource "github.com/openshift-pipelines/release-tests/pkg/config"
-	"google.golang.org/genproto/googleapis/api/annotations"
-	"knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace"
 )
 
 // Create resources using oc command

--- a/pkg/oc/oc.go
+++ b/pkg/oc/oc.go
@@ -8,6 +8,8 @@ import (
 	"github.com/getgauge-contrib/gauge-go/testsuit"
 	"github.com/openshift-pipelines/release-tests/pkg/cmd"
 	resource "github.com/openshift-pipelines/release-tests/pkg/config"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace"
 )
 
 // Create resources using oc command
@@ -73,6 +75,10 @@ func UpdateTektonConfigwithInvalidData(patch_data, errorMessage string) {
 
 func AnnotateNamespace(namespace, annotation string) {
 	log.Printf("output: %s\n", cmd.MustSucceed("oc", "annotate", "namespace", namespace, annotation).Stdout())
+}
+
+func AnnotateNamespaceIgnoreErrors(namespace, annotation string) {
+	log.Printf("output: %s\n", cmd.Run("oc", "annotate", "namespace", namespace, annotation).Stdout())
 }
 
 func RemovePrunerConfig() {

--- a/specs/pipelines/run.spec
+++ b/specs/pipelines/run.spec
@@ -76,7 +76,7 @@ Steps:
   * Create
       |S.NO|resource_dir                                 |
       |----|---------------------------------------------|
-      |1   |testdata/pvc.yaml                             |
+      |1   |testdata/pvc.yaml                            |
       |2   |testdata/v1beta1/pipelinerun/pipelinerun.yaml|
   * Verify pipelinerun
       |S.NO|pipeline_run_name       |status   |check_label_propagation|

--- a/specs/pipelines/run.spec
+++ b/specs/pipelines/run.spec
@@ -21,7 +21,8 @@ Steps:
   * Create
       |S.NO|resource_dir                                  |
       |----|----------------------------------------------|
-      |1   |testdata/v1beta1/pipelinerun/pipelinerun.yaml |
+      |1   |testdata/pvc.yaml                             |
+      |2   |testdata/v1beta1/pipelinerun/pipelinerun.yaml |
   * Verify pipelinerun
       |S.NO|pipeline_run_name       |status    |check_label_propagation|
       |----|------------------------|----------|-----------------------|
@@ -75,7 +76,8 @@ Steps:
   * Create
       |S.NO|resource_dir                                 |
       |----|---------------------------------------------|
-      |1   |testdata/v1beta1/pipelinerun/pipelinerun.yaml|
+      |1   |testdata/pvc.yaml                             |
+      |2   |testdata/v1beta1/pipelinerun/pipelinerun.yaml|
   * Verify pipelinerun
       |S.NO|pipeline_run_name       |status   |check_label_propagation|
       |----|------------------------|---------|-----------------------|

--- a/steps/hooks.go
+++ b/steps/hooks.go
@@ -3,19 +3,22 @@ package steps
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
 	"github.com/getgauge-contrib/gauge-go/gauge"
+	"github.com/getgauge-contrib/gauge-go/gauge_messages"
 	"github.com/getgauge-contrib/gauge-go/testsuit"
 	"github.com/openshift-pipelines/release-tests/pkg/config"
 	"github.com/openshift-pipelines/release-tests/pkg/k8s"
 	"github.com/openshift-pipelines/release-tests/pkg/oc"
+	"github.com/openshift-pipelines/release-tests/pkg/store"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Runs Before every Secenario
-var _ = gauge.BeforeScenario(func() {
+var _ = gauge.BeforeScenario(func(exInfo *gauge_messages.ExecutionInfo) {
 	cs, namespace, cleanup := k8s.NewClientSet()
 	crNames := config.ResourceNames{
 		TektonPipeline:  "pipeline",
@@ -33,21 +36,34 @@ var _ = gauge.BeforeScenario(func() {
 	store["scenario.cleanup"] = cleanup
 	store["targetNamespace"] = config.TargetNamespace
 
+	autoPruneTagPresent := true
+	for _, tag := range exInfo.CurrentScenario.Tags {
+		if tag == "auto-prune" {
+			autoPruneTagPresent = false
+		}
+	}
+	if !autoPruneTagPresent {
+		oc.AnnotateNamespace(namespace, "operator.tekton.dev/prune.skip=true")
+	}
 	oc.Create("testdata/pvc.yaml", namespace)
 }, []string{}, testsuit.AND)
 
 // Runs After every Secenario
-var _ = gauge.AfterScenario(func() {
+var _ = gauge.AfterScenario(func(exInfo *gauge_messages.ExecutionInfo) {
 	switch c := gauge.GetScenarioStore()["scenario.cleanup"].(type) {
 	case func():
-		c()
+		if exInfo.CurrentSpec.IsFailed {
+			c()
+		} else {
+			log.Printf("Skipping deletion of namespace %s as the test got failed", store.Namespace())
+		}
 	default:
 		testsuit.T.Errorf("Error: return type is not of type func()")
 	}
 }, []string{}, testsuit.AND)
 
 // Store default pruner config
-var _ = gauge.BeforeSpec(func() {
+var _ = gauge.BeforeSpec(func(exInfo *gauge_messages.ExecutionInfo) {
 	cs, _, _ := k8s.NewClientSet()
 
 	tc, err := cs.TektonConfig().Get(context.TODO(), config.TektonConfigName, metav1.GetOptions{})
@@ -71,7 +87,7 @@ var _ = gauge.BeforeSpec(func() {
 }, []string{"auto-prune"}, testsuit.AND)
 
 // Revert changes made by pruner tests
-var _ = gauge.AfterSpec(func() {
+var _ = gauge.AfterSpec(func(exInfo *gauge_messages.ExecutionInfo) {
 	keep := gauge.GetSpecStore()["keep"]
 	keepSince := gauge.GetSpecStore()["keepSince"]
 	resources := gauge.GetSpecStore()["resources"].([]string)

--- a/steps/hooks.go
+++ b/steps/hooks.go
@@ -53,9 +53,9 @@ var _ = gauge.AfterScenario(func(exInfo *gauge_messages.ExecutionInfo) {
 	switch c := gauge.GetScenarioStore()["scenario.cleanup"].(type) {
 	case func():
 		if exInfo.CurrentSpec.IsFailed {
-			c()
-		} else {
 			log.Printf("Skipping deletion of namespace %s as the test got failed", store.Namespace())
+		} else {
+			c()
 		}
 	default:
 		testsuit.T.Errorf("Error: return type is not of type func()")

--- a/steps/hooks.go
+++ b/steps/hooks.go
@@ -81,7 +81,7 @@ var _ = gauge.BeforeSpec(func(exInfo *gauge_messages.ExecutionInfo) {
 	}
 	log.Print("Annotating the namespaces with 'operator.tekton.dev/prune.skip=true' so that the pipelineruns should not get deleted")
 	for _, ns := range namespaces.Items {
-		if !(strings.HasPrefix("openshift", ns.Name) || strings.HasPrefix("kube", ns.Name)) {
+		if !(strings.HasPrefix(ns.Name, "openshift-") || strings.HasPrefix(ns.Name, "kube-")) {
 			oc.AnnotateNamespaceIgnoreErrors(ns.Name, "operator.tekton.dev/prune.skip=true")
 		}
 	}

--- a/steps/hooks.go
+++ b/steps/hooks.go
@@ -42,7 +42,7 @@ var _ = gauge.AfterScenario(func(exInfo *gauge_messages.ExecutionInfo) {
 	switch c := gauge.GetScenarioStore()["scenario.cleanup"].(type) {
 	case func():
 		if exInfo.CurrentSpec.IsFailed {
-			log.Printf("Skipping deletion of namespace %s as the test got failed", store.Namespace())
+			log.Printf("Skipping deletion of the namespace '%s' as the test got failed", store.Namespace())
 		} else {
 			c()
 		}
@@ -79,9 +79,10 @@ var _ = gauge.BeforeSpec(func(exInfo *gauge_messages.ExecutionInfo) {
 	if err != nil {
 		log.Printf("Warning: Could not annotate other namespace as issue getting namespaces: %v", err)
 	}
+	log.Print("Annotating the namespaces with 'operator.tekton.dev/prune.skip=true' so that the pipelineruns should not get deleted")
 	for _, ns := range namespaces.Items {
-		if ! (strings.HasPrefix("openshift", ns.Name) || strings.HasPrefix("kube", ns.Name)) {
-			oc.AnnotateNamespace(ns.Name, "operator.tekton.dev/prune.skip=true")
+		if !(strings.HasPrefix("openshift", ns.Name) || strings.HasPrefix("kube", ns.Name)) {
+			oc.AnnotateNamespaceIgnoreErrors(ns.Name, "operator.tekton.dev/prune.skip=true")
 		}
 	}
 

--- a/steps/hooks.go
+++ b/steps/hooks.go
@@ -36,16 +36,16 @@ var _ = gauge.BeforeScenario(func(exInfo *gauge_messages.ExecutionInfo) {
 	store["scenario.cleanup"] = cleanup
 	store["targetNamespace"] = config.TargetNamespace
 
-	autoPruneTagPresent := true
+	autoPruneTagPresent := false
 	for _, tag := range exInfo.CurrentScenario.Tags {
 		if tag == "auto-prune" {
-			autoPruneTagPresent = false
+			autoPruneTagPresent = true
+			break
 		}
 	}
 	if !autoPruneTagPresent {
 		oc.AnnotateNamespace(namespace, "operator.tekton.dev/prune.skip=true")
 	}
-	oc.Create("testdata/pvc.yaml", namespace)
 }, []string{}, testsuit.AND)
 
 // Runs After every Secenario


### PR DESCRIPTION
 - Adding the annotation to the newly created namespace so that the
 pruner will not delete the pipelineruns
 - Annotation is not added when executing auto-prune related test cases