### PR TITLE
Updating installersets prefix names

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,7 +63,7 @@ const (
 )
 
 // Name prefixes of installerset
-var TektonInstallersetNamePrefixes [14]string = [14]string{"addon-clustertasks", "addon-communityclustertasks", "addon-consolecli", "addon-openshift", "addon-pac", "addon-pipelines", "addon-triggers", "addon-versioned-clustertasks", "pipeline", "postpipeline", "prepipeline", "rhosp-rbac", "trigger", "validating-mutating-webhoook"}
+var TektonInstallersetNamePrefixes [18]string = [18]string{"addon-custom-clustertask", "addon-custom-communityclustertask", "addon-custom-consolecli", "addon-custom-openshiftconsole", "addon-custom-pipelinestemplate", "addon-custom-triggersresources", "addon-versioned-clustertasks", "openshiftpipelinesascode-main-deployment", "openshiftpipelinesascode-main-static", "openshiftpipelinesascode-post", "pipeline-main-deployment", "pipeline-main-static", "pipeline-post", "pipeline-pre", "rhosp-rbac", "trigger-main-deployment", "trigger-main-static", "validating-mutating-webhoook"}
 
 var PrefixesOfDefaultPipelines [9]string = [9]string{"buildah", "s2i-dotnet", "s2i-go", "s2i-java", "s2i-nodejs", "s2i-perl", "s2i-php", "s2i-python", "s2i-ruby"}
 


### PR DESCRIPTION
There has been a change in the names of tektoninstallersets. 
This PR updates the name prefix of tektoninstallersets