### PR TITLE
Updating rbac test

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -25,6 +25,7 @@ func ValidateRBAC(cs *clients.Clients, rnames utils.ResourceNames) {
 	AssertConfigMapPresent(cs, store.Namespace(), "config-trusted-cabundle")
 	AssertRoleBindingPresent(cs, store.Namespace(), "openshift-pipelines-edit")
 	AssertRoleBindingPresent(cs, store.Namespace(), "pipelines-scc-rolebinding")
+	AssertSCCPresent(cs, "pipelines-scc")
 }
 
 func ValidateRBACAfterDisable(cs *clients.Clients, rnames utils.ResourceNames) {
@@ -39,6 +40,7 @@ func ValidateRBACAfterDisable(cs *clients.Clients, rnames utils.ResourceNames) {
 	//Verify roleBindings is not created in any namespace
 	AssertRoleBindingNotPresent(cs, store.Namespace(), "edit")
 	AssertRoleBindingNotPresent(cs, store.Namespace(), "pipelines-scc-rolebinding")
+	AssertSCCNotPresent(cs, "pipelines-scc")
 }
 
 func ValidatePipelineDeployments(cs *clients.Clients, rnames utils.ResourceNames) {

--- a/pkg/operator/rbac.go
+++ b/pkg/operator/rbac.go
@@ -168,7 +168,7 @@ func AssertClusterRoleNotPresent(clients *clients.Clients, clusterRoleName strin
 func AssertSCCPresent(clients *clients.Clients, sccName string) {
 	s := scc.NewForConfigOrDie(clients.KubeConfig)
 	err := wait.Poll(config.APIRetry, config.APITimeout, func() (bool, error) {
-		log.Printf("Verifying that security context contstraint %s exists\n", sccName)
+		log.Printf("Verifying that security context constraint %s exists\n", sccName)
 		sccList, err := s.SecurityV1().SecurityContextConstraints().List(clients.Ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -181,7 +181,7 @@ func AssertSCCPresent(clients *clients.Clients, sccName string) {
 		return false, nil
 	})
 	if err != nil {
-		assert.FailOnError(fmt.Errorf("Expected: security context constraint %q present, Actual: secirity context constraint %q not present , Error: %v", sccName, sccName, err))
+		assert.FailOnError(fmt.Errorf("Expected: security context constraint %q present, Actual: security context constraint %q not present , Error: %v", sccName, sccName, err))
 	}
 }
 
@@ -201,6 +201,6 @@ func AssertSCCNotPresent(clients *clients.Clients, sccName string) {
 		return true, err
 	})
 	if err != nil {
-		assert.FailOnError(fmt.Errorf("Expected, secuirty context constraint %q not present, Actual: securit context constraint %q present, Error: %v", sccName, sccName, err))
+		assert.FailOnError(fmt.Errorf("Expected: secuirty context constraint %q not present, Actual: security context constraint %q present, Error: %v", sccName, sccName, err))
 	}
 }


### PR DESCRIPTION
As the bug https://issues.redhat.com/browse/SRVKP-2520 is fixed, now even the `pipeline-scc` security context constraint get removed when we disable rbac from config CR