### PR TITLE
Skipping annotating default namespace

### DIFF
--- a/steps/hooks.go
+++ b/steps/hooks.go
@@ -83,7 +83,7 @@ var _ = gauge.BeforeSpec(func(exInfo *gauge_messages.ExecutionInfo) {
 	}
 	log.Print("Annotating the namespaces with 'operator.tekton.dev/prune.skip=true' so that the pipelineruns should not get deleted")
 	for _, ns := range namespaces.Items {
-		if !(strings.HasPrefix(ns.Name, "openshift-") || strings.HasPrefix(ns.Name, "kube-")) {
+		if !(strings.HasPrefix(ns.Name, "openshift-") || strings.HasPrefix(ns.Name, "kube-") || ns.Name == "default") {
 			oc.AnnotateNamespaceIgnoreErrors(ns.Name, "operator.tekton.dev/prune.skip=true")
 		}
 	}


### PR DESCRIPTION
Since we were annotating all the namespace, there was no namespaces present to be pruned so pruner cronjob was not getting created