### PR TITLE
add dockerfile for interop testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# Using base image which has requirements (go, gauge) installed
+FROM quay.io/openshift-pipeline/ci
+
+# Set WORKDIR to /root/release-tests and copy the tests
+RUN mkdir /root/release-tests
+WORKDIR /root/release-tests
+COPY . .
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,20 @@
 # Using base image which has requirements (go, gauge) installed
 FROM quay.io/openshift-pipeline/ci
 
-# Set WORKDIR to /root/release-tests and copy the tests
-RUN mkdir /root/release-tests
-WORKDIR /root/release-tests
+# Set this var to install gauge plugins at custom path
+ENV GAUGE_HOME=/tmp
+
+# Add timeout to ignore runner connection error
+RUN gauge config runner_connection_timeout 600000 && \
+    gauge config runner_request_timeout 300000
+
+# Copy the tests into /tmp/release-tests
+RUN mkdir /tmp/release-tests
+WORKDIR /tmp/release-tests
 COPY . .
+
+# Set required permissions for OpenShift usage
+RUN chgrp -R 0 /tmp && \
+    chmod -R g=u /tmp
 
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -103,3 +103,6 @@ podman run --rm -it -v $KUBECONFIG:/root/.kube/config:z -v .:/root/release-tests
 gauge run ...
 ```
 
+## Containerised Tests
+
+[Dockerfile](Dockerfile) is added to execute openshift-pipelines tests in a framework that requires that setup and tests be performed from a container.


### PR DESCRIPTION
Adding Dockerfile to support Interop Testing in Openshift CI.
Link to the ticket: [LPTOCPCI-243](https://issues.redhat.com/browse/LPTOCPCI-243)
This Dockerfile will unblock this ticket: [LPTOCPCI-240](https://issues.redhat.com/browse/LPTOCPCI-240)

Needed for this PR: https://github.com/openshift/release/pull/39156
passed job [link](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/39156/rehearse-39156-periodic-ci-chetna14manku-release-tests-interop-v1.10-openshift-pipelines-ocp4.14-lp-interop-openshift-pipelines-interop-aws/1684253484024598528)