### PR TITLE
Hub resolvers test

### DIFF
--- a/specs/olm.spec
+++ b/specs/olm.spec
@@ -11,9 +11,29 @@ Importance: Critical
 Installs `openshift-pipelines` operator using olm
 
 Steps:
+  * Subscribe to operator
+  * Wait for TektonConfig CR availability  
+  * Change enable-api-fields to "beta"
   * Define the tekton-hub-api variable
-
-  
+  * Verify namespace "openshift-pipelines" exists
+  * Apply
+    | S.NO | resource_dir                   |
+    |------|--------------------------------|
+    | 1    | testdata/hub/tektonhub.yaml    |
+  * Configure GitHub token for git resolver in TektonConfig
+  * Configure the bundles resolver
+  * Validate pipelines deployment
+  * Validate triggers deployment
+  * Validate PAC deployment
+  * Validate chains deployment
+  * Validate hub deployment
+  * Validate tkn server cli deployment
+  * Verify TektonAddons Install status
+  * Validate RBAC
+  * Validate quickstarts
+  * Validate default auto prune cronjob in target namespace
+  * Validate tektoninstallersets status
+  * Validate tektoninstallersets names
 
 ## Upgrade openshift-pipelines operator: PIPELINES-09-TC02
 Tags: upgrade, admin

--- a/specs/olm.spec
+++ b/specs/olm.spec
@@ -11,28 +11,8 @@ Importance: Critical
 Installs `openshift-pipelines` operator using olm
 
 Steps:
-  * Subscribe to operator
-  * Wait for TektonConfig CR availability  
-  * Change enable-api-fields to "beta"
-  * Verify namespace "openshift-pipelines" exists
-  * Apply
-    | S.NO | resource_dir                   |
-    |------|--------------------------------|
-    | 1    | testdata/hub/tektonhub.yaml    |
-  * Configure GitHub token for git resolver in TektonConfig
-  * Configure the bundles resolver
-  * Validate pipelines deployment
-  * Validate triggers deployment
-  * Validate PAC deployment
-  * Validate chains deployment
-  * Validate hub deployment
-  * Validate tkn server cli deployment
-  * Verify TektonAddons Install status
-  * Validate RBAC
-  * Validate quickstarts
-  * Validate default auto prune cronjob in target namespace
-  * Validate tektoninstallersets status
-  * Validate tektoninstallersets names
+  * Define the tekton-hub-api variable
+
   
 
 ## Upgrade openshift-pipelines operator: PIPELINES-09-TC02

--- a/specs/pipelines/hub-resolvers.spec
+++ b/specs/pipelines/hub-resolvers.spec
@@ -1,0 +1,22 @@
+# HUB resolvers spec
+Pre condition:
+  * Validate Operator should be installed
+## Test the functionality of hub resolvers
+Tags: e2e, sanity
+Component: Resolvers
+Level: Integration
+Type: Functional
+Importance: High
+
+Steps:
+    * Verify ServiceAccount "pipeline" exist
+    * Apply  
+      |S.NO|resource_dir                                     |
+      |----|-------------------------------------------------|
+      |1   |testdata/resolvers/pipelines/git-cli-hub.yaml    |
+      |2   |testdata/pvc/pvc.yaml                            |
+      |3   |testdata/resolvers/pipelineruns/git-cli-hub.yaml |
+    * Verify pipelinerun
+      |S.NO|pipeline_run_name|status    |check_label_propagation|
+      |----|-----------------|----------|-----------------------|
+      |1   |hub-git-cli-run  |successful|no                     |

--- a/steps/cli/oc.go
+++ b/steps/cli/oc.go
@@ -143,6 +143,12 @@ var _ = gauge.Step("Change enable-api-fields to <version>", func(version string)
 	oc.UpdateTektonConfig(patch_data)
 })
 
+var _ = gauge.Step("Define the tekton-hub-api variable", func (){
+	patch_data := "{\"spec\":{\"pipeline\":{\"hub-resolver-config\":{\"tekton-hub-api\":\"https://api.hub.tekton.dev/\"}}}}"
+	oc.UpdateTektonConfig(patch_data)
+
+})
+
 var _ = gauge.Step("Configure GitHub token for git resolver in TektonConfig", func() {
 	if os.Getenv("GITHUB_TOKEN") == "" {
 		log.Printf("Token for authorization to the GitHub repository was not exported as a system variable")

--- a/testdata/resolvers/pipelineruns/git-cli-hub.yaml
+++ b/testdata/resolvers/pipelineruns/git-cli-hub.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: hub-git-cli-run

--- a/testdata/resolvers/pipelineruns/git-cli-hub.yaml
+++ b/testdata/resolvers/pipelineruns/git-cli-hub.yaml
@@ -3,7 +3,6 @@ kind: PipelineRun
 metadata:
   name: hub-git-cli-run
 spec:
-  # serviceAccountName: git-service-account
   pipelineRef:
     name: hub-git-cli-pipeline
   timeouts: 

--- a/testdata/resolvers/pipelineruns/git-cli-hub.yaml
+++ b/testdata/resolvers/pipelineruns/git-cli-hub.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: hub-git-cli-run
+spec:
+  # serviceAccountName: git-service-account
+  pipelineRef:
+    name: hub-git-cli-pipeline
+  timeouts: 
+    pipeline: 5m
+  workspaces:
+    - name: shared-workspace
+      persistentVolumeClaim:
+        claimName: shared-pvc
+    - name: input
+      emptyDir: {}

--- a/testdata/resolvers/pipelines/git-cli-hub.yaml
+++ b/testdata/resolvers/pipelines/git-cli-hub.yaml
@@ -1,0 +1,69 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: hub-git-cli-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: input
+  tasks:
+    - name: clone-git-repo
+      taskRef:
+        resolver: hub
+        params:
+          - name: type
+            value: tekton
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: version
+            value: "0.9"
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/kelseyhightower/nocode
+        - name: subdirectory
+          value: "git-cli-hub"
+        - name: deleteExisting
+          value: "true"
+    - name: git-cli
+      taskRef:
+        resolver: hub
+        params: 
+          - name: type
+            value: tekton
+          - name: kind
+            value: task
+          - name: name  
+            value: git-cli
+          - name: version
+            value: "0.4"
+      runAfter:
+        - clone-git-repo
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: input
+          workspace: input
+      params:
+        - name: subdirectory
+          value: "git-cli-hub"
+        - name: GIT_USER_NAME
+          value: git_username
+        - name: GIT_USER_EMAIL
+          value: git_email
+        - name: GIT_SCRIPT
+          value: |
+            cd git-cli
+            git config --global safe.directory "*"
+            echo "Hello" > hello
+            git add .
+            git status
+            git commit -m "Add sample file"
+            git log --oneline -5
+  results:
+    - name: commit
+      value: $(tasks.git-cli.results.commit)

--- a/testdata/resolvers/pipelines/git-cli-hub.yaml
+++ b/testdata/resolvers/pipelines/git-cli-hub.yaml
@@ -57,7 +57,7 @@ spec:
           value: git_email
         - name: GIT_SCRIPT
           value: |
-            cd git-cli
+            cd git-cli-hub
             git config --global safe.directory "*"
             echo "Hello" > hello
             git add .


### PR DESCRIPTION
In order for the test works correctly, you need first set the  TEKTON_HUB_API env to “https://api.hub.tekton.dev/” in the deployments to set the hub resolver to public endpoint.