### PR TITLE
Remove cron verification step

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift-pipelines/release-tests/pkg/oc"
 	"github.com/openshift-pipelines/release-tests/pkg/openshift"
 	"github.com/openshift-pipelines/release-tests/pkg/store"
-	w "github.com/openshift-pipelines/release-tests/pkg/wait"
 	secv1 "github.com/openshift/api/security/v1"
 	secclient "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	"github.com/tektoncd/pipeline/pkg/names"
@@ -257,27 +256,6 @@ func CreateCronJob(c *clients.Clients, args []string, schedule, namespace string
 	}
 	log.Printf("Cronjob: %s created in namespace: %s", cj.Name, namespace)
 	store.PutScenarioData("cronjob", cj.Name)
-}
-
-func WaitForActiveCronJobs(c *clients.Clients, active int, cronJobName, ns string) wait.ConditionFunc {
-	return func() (bool, error) {
-		curr, err := GetCronJob(c, ns, cronJobName)
-		if err != nil {
-			return false, err
-		}
-		return len(curr.Status.Active) >= active, nil
-	}
-}
-
-func WaitForCronJobToBeSceduled(c *clients.Clients, activejobs int, job, namespace string) {
-	err := w.WaitFor(c.Ctx, WaitForActiveCronJobs(c, activejobs, job, namespace))
-	if err != nil {
-		testsuit.T.Errorf("failed to schedule cron job %s in namespace %s \n %v", job, namespace, err)
-	}
-}
-
-func GetCronJob(c *clients.Clients, ns, name string) (*batchv1.CronJob, error) {
-	return c.KubeClient.Kube.BatchV1().CronJobs(ns).Get(c.Ctx, name, metav1.GetOptions{})
 }
 
 func DeleteCronJob(c *clients.Clients, name, ns string) error {

--- a/specs/triggers/cron.spec
+++ b/specs/triggers/cron.spec
@@ -24,7 +24,6 @@ Steps:
   * Expose Event listener "cron-listener"
   * Verify that image stream "golang" exists
   * Create cron job with schedule "*/1 * * * *"
-  * Wait for cron job to be active
   * Watch for pipelinerun resources
   * Delete cron job
   * Assert no new pipelineruns created

--- a/steps/k8s/k8s.go
+++ b/steps/k8s/k8s.go
@@ -24,10 +24,6 @@ var _ = gauge.Step("Create cron job with schedule <schedule>", func(schedule str
 	k8s.CreateCronJob(store.Clients(), args, schedule, store.Namespace())
 })
 
-var _ = gauge.Step("Wait for cron job to be active", func() {
-	k8s.WaitForCronJobToBeSceduled(store.Clients(), 1, store.GetScenarioData("cronjob"), store.Namespace())
-})
-
 var _ = gauge.Step("Delete cron job", func() {
 	k8s.DeleteCronJob(store.Clients(), store.GetScenarioData("cronjob"), store.Namespace())
 })


### PR DESCRIPTION
I removed the cronjob verification step which was looking for active jobs greater than zero. The job will be active for only a few seconds and there are chances that it will fall between the polling interval. Hence I removed the step.