### PR TITLE
Fixing namespace keeping issue

### DIFF
--- a/steps/hooks.go
+++ b/steps/hooks.go
@@ -43,7 +43,7 @@ var _ = gauge.BeforeScenario(func(exInfo *gauge_messages.ExecutionInfo) {
 var _ = gauge.AfterScenario(func(exInfo *gauge_messages.ExecutionInfo) {
 	switch c := gauge.GetScenarioStore()["scenario.cleanup"].(type) {
 	case func():
-		if exInfo.CurrentSpec.IsFailed {
+		if exInfo.CurrentScenario.IsFailed {
 			log.Printf("Skipping deletion of the namespace '%s' as the test got failed", store.Namespace())
 		} else {
 			c()


### PR DESCRIPTION
the `exInfo.CurrentSpec.IsFailed` would be marked as `true` if any of the test scenarios in the spec fails. Which causes namespace deletion to be skipped for all the test scenarios that come after the failed scenario. Changing it to `exInfo.CurrentScenario.IsFailed` would fix that issue.