### PR TITLE
Giving execute permission for cosign to all users

### DIFF
--- a/Dockerfile.CI
+++ b/Dockerfile.CI
@@ -56,7 +56,7 @@ RUN wget https://github.com/getgauge/gauge/releases/download/v${GAUGE_VERSION}/g
     gauge version
 
 RUN wget https://github.com/sigstore/cosign/releases/download/v2.2.3/cosign-linux-amd64 -O /usr/bin/cosign && \
-    chmod u+x /usr/bin/cosign
+    chmod a+x /usr/bin/cosign
 
 RUN wget https://github.com/sigstore/rekor/releases/download/v1.3.5/rekor-cli-linux-amd64 -O /usr/bin/rekor-cli && \
     chmod u+x /usr/bin/rekor-cli


### PR DESCRIPTION
The interop tests are failing because non root user is executing the tests and cosign is having execute permission only for root user.