### PR TITLE
Ignore errors while deleting project

### DIFF
--- a/steps/cli/oc.go
+++ b/steps/cli/oc.go
@@ -149,7 +149,7 @@ var _ = gauge.Step("Create project <projectName>", func(projectName string) {
 
 var _ = gauge.Step("Delete project <projectName>", func(projectName string) {
 	log.Printf("Deleting project %v", projectName)
-	oc.DeleteProject(projectName)
+	oc.DeleteProjectIgnoreErors(projectName)
 })
 
 var _ = gauge.Step("Link secret <secret> to service account <sa>", func(secret, sa string) {


### PR DESCRIPTION
As the interop team is running tests on the IBM cloud, a few of the tests which have a step to delete the namespace are failing because of some environmental issue. As the error in deleting the namespace should not be considered as a test failure, we want to remove the namespace deletion verification part from the tests.