### PR TITLE
Fixing the metrics test

### DIFF
--- a/pkg/monitoring/prometheus.go
+++ b/pkg/monitoring/prometheus.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/openshift-pipelines/release-tests/pkg/clients"
+	"github.com/openshift-pipelines/release-tests/pkg/cmd"
 	"github.com/openshift-pipelines/release-tests/pkg/config"
 
 	v1 "github.com/openshift/api/route/v1"
@@ -146,7 +147,19 @@ func getBearerTokenForPrometheusAccount(cs *clients.Clients) (string, error) {
 	}
 	tokenSecret := getPrometheusSecretNameForToken(secrets.Items)
 	if tokenSecret == "" {
-		return "", errors.New("token secret with prefix \"prometheus-k8s\" service account not found")
+		// generate token for service account prometheus-k8s
+		output := cmd.Run("oc", "sa", "new-token", "prometheus-k8s", "-n", "openshift-monitoring")
+		if output.ExitCode != 0 {
+			return "", errors.New(fmt.Sprintf("error creating token for the service account prometheus-k8s: %v", output.Stderr()))
+		}
+		secrets, err := cs.KubeClient.Kube.CoreV1().Secrets("openshift-monitoring").List(context.Background(), meta.ListOptions{})
+		if err != nil {
+			return "", fmt.Errorf("error getting secrets from namespace %v: %v", "openshift-monitoring", err)
+		}
+		tokenSecret = getPrometheusSecretNameForToken(secrets.Items)
+		if tokenSecret == "" {
+			return "", errors.New("could not find a service account token for service account \"prometheus-k8s\"")
+		}
 	}
 	sec, err := cs.KubeClient.Kube.CoreV1().Secrets("openshift-monitoring").Get(context.Background(), tokenSecret, meta.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
The metrics test case used to fail if the secret which contains the token is not available. I have updated the test to create the secret with the token if it is unavailable.