### PR TITLE
golang-lint udpated to 1.61.0, lint issues fixed

### DIFF
--- a/Dockerfile.CI
+++ b/Dockerfile.CI
@@ -65,7 +65,7 @@ RUN wget https://github.com/sigstore/cosign/releases/download/v2.4.0/cosign-linu
 RUN wget https://github.com/sigstore/rekor/releases/download/v1.3.6/rekor-cli-linux-amd64 -O /usr/bin/rekor-cli && \
     chmod u+x /usr/bin/rekor-cli
 
-ENV GOLANGCI_LINT_VERSION=1.59.1
+ENV GOLANGCI_LINT_VERSION=1.61.0
 RUN wget -O /tmp/golangci-lint.tar.gz https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.tar.gz \
     && tar --strip-components=1 -C /usr/bin -xzf /tmp/golangci-lint.tar.gz golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64/golangci-lint \
     && rm -f /tmp/golangci-lint.tar.gz

--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -36,23 +36,21 @@ func validatePipelineRunForSuccessStatus(c *clients.Clients, prname, labelCheck,
 	// Verify status of PipelineRun (wait for it)
 	err := wait.WaitForPipelineRunState(c, prname, wait.PipelineRunSucceed(prname), "PipelineRunCompleted")
 	if err != nil {
-		var printMsg string
 		buf, logsErr := getPipelinerunLogs(c, prname, namespace)
 		events, eventError := k8s.GetWarningEvents(c, namespace)
 		if logsErr != nil {
 			if eventError != nil {
-				printMsg = fmt.Sprintf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs error: \n%v \npipelinerun events error: \n%v", prname, err, logsErr, eventError)
+				testsuit.T.Errorf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs error: \n%v \npipelinerun events error: \n%v", prname, err, logsErr, eventError)
 			} else {
-				printMsg = fmt.Sprintf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs error: \n%v \npipelinerun events: \n%v", prname, err, logsErr, events)
+				testsuit.T.Errorf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs error: \n%v \npipelinerun events: \n%v", prname, err, logsErr, events)
 			}
 		} else {
 			if eventError != nil {
-				printMsg = fmt.Sprintf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs: \n%v \npipelinerun events error: \n%v", prname, err, buf.String(), eventError)
+				testsuit.T.Errorf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs: \n%v \npipelinerun events error: \n%v", prname, err, buf.String(), eventError)
 			} else {
-				printMsg = fmt.Sprintf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs: \n%v \npipelinerun events: \n%v", prname, err, buf.String(), events)
+				testsuit.T.Errorf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs: \n%v \npipelinerun events: \n%v", prname, err, buf.String(), events)
 			}
 		}
-		testsuit.T.Errorf(printMsg)
 	}
 
 	log.Printf("pipelineRun: %s is successful under namespace : %s", prname, namespace)
@@ -86,23 +84,21 @@ func validatePipelineRunForFailedStatus(c *clients.Clients, prname, namespace st
 	log.Printf("Waiting for PipelineRun in namespace %s to fail", namespace)
 	err = wait.WaitForPipelineRunState(c, prname, wait.PipelineRunFailed(prname), "BuildValidationFailed")
 	if err != nil {
-		var printMsg string
 		buf, logsErr := getPipelinerunLogs(c, prname, namespace)
 		events, eventError := k8s.GetWarningEvents(c, namespace)
 		if logsErr != nil {
 			if eventError != nil {
-				printMsg = fmt.Sprintf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs error: \n%v \npipelinerun events error: \n%v", prname, err, logsErr, eventError)
+				testsuit.T.Errorf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs error: \n%v \npipelinerun events error: \n%v", prname, err, logsErr, eventError)
 			} else {
-				printMsg = fmt.Sprintf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs error: \n%v \npipelinerun events: \n%v", prname, err, logsErr, events)
+				testsuit.T.Errorf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs error: \n%v \npipelinerun events: \n%v", prname, err, logsErr, events)
 			}
 		} else {
 			if eventError != nil {
-				printMsg = fmt.Sprintf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs: \n%v \npipelinerun events error: \n%v", prname, err, buf.String(), eventError)
+				testsuit.T.Errorf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs: \n%v \npipelinerun events error: \n%v", prname, err, buf.String(), eventError)
 			} else {
-				printMsg = fmt.Sprintf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs: \n%v \npipelinerun events: \n%v", prname, err, buf.String(), events)
+				testsuit.T.Errorf("error waiting for pipeline run %s to finish \n%v \npipelinerun logs: \n%v \npipelinerun events: \n%v", prname, err, buf.String(), events)
 			}
 		}
-		testsuit.T.Errorf(printMsg)
 	}
 }
 

--- a/pkg/pipelines/taskrun.go
+++ b/pkg/pipelines/taskrun.go
@@ -2,7 +2,6 @@ package pipelines
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"os"
 	"regexp"
@@ -43,23 +42,21 @@ func validateTaskRunForFailedStatus(c *clients.Clients, trname, namespace string
 	log.Printf("Waiting for TaskRun %s in namespace %s to fail", trname, namespace)
 	err = wait.WaitForTaskRunState(c, trname, wait.TaskRunFailed(trname), "BuildValidationFailed")
 	if err != nil {
-		var printMsg string
 		buf, logsErr := getTaskrunLogs(c, trname, namespace)
 		events, eventError := k8s.GetWarningEvents(c, namespace)
 		if logsErr != nil {
 			if eventError != nil {
-				printMsg = fmt.Sprintf("task run %s was expected to be in TaskRunFailed state \n%v \ntaskrun logs error: \n%v \ntaskrun events error: \n%v", trname, err, logsErr, eventError)
+				testsuit.T.Errorf("task run %s was expected to be in TaskRunFailed state \n%v \ntaskrun logs error: \n%v \ntaskrun events error: \n%v", trname, err, logsErr, eventError)
 			} else {
-				printMsg = fmt.Sprintf("task run %s was expected to be in TaskRunFailed state \n%v \ntaskrun logs error: \n%v \ntaskrun events: \n%v", trname, err, logsErr, events)
+				testsuit.T.Errorf("task run %s was expected to be in TaskRunFailed state \n%v \ntaskrun logs error: \n%v \ntaskrun events: \n%v", trname, err, logsErr, events)
 			}
 		} else {
 			if eventError != nil {
-				printMsg = fmt.Sprintf("task run %s was expected to be in TaskRunFailed state \n%v \ntaskrun logs: \n%v \ntaskrun events error: \n%v", trname, err, buf.String(), eventError)
+				testsuit.T.Errorf("task run %s was expected to be in TaskRunFailed state \n%v \ntaskrun logs: \n%v \ntaskrun events error: \n%v", trname, err, buf.String(), eventError)
 			} else {
-				printMsg = fmt.Sprintf("task run %s was expected to be in TaskRunFailed state \n %v \ntaskrun logs: \n%v \ntaskrun events: \n%v", trname, err, buf.String(), events)
+				testsuit.T.Errorf("task run %s was expected to be in TaskRunFailed state \n %v \ntaskrun logs: \n%v \ntaskrun events: \n%v", trname, err, buf.String(), events)
 			}
 		}
-		testsuit.T.Errorf(printMsg)
 	}
 }
 
@@ -68,23 +65,21 @@ func validateTaskRunForSuccessStatus(c *clients.Clients, trname, namespace strin
 	log.Printf("Waiting for TaskRun %s in namespace %s to succeed", trname, namespace)
 	err = wait.WaitForTaskRunState(c, trname, wait.TaskRunSucceed(trname), "TaskRunSucceed")
 	if err != nil {
-		var printMsg string
 		buf, logsErr := getTaskrunLogs(c, trname, namespace)
 		events, eventError := k8s.GetWarningEvents(c, namespace)
 		if logsErr != nil {
 			if eventError != nil {
-				printMsg = fmt.Sprintf("task run %s was expected to be in TaskRunSucceed state \n%v \ntaskrun logs error: \n%v \ntaskrun events error: \n%v", trname, err, logsErr, eventError)
+				testsuit.T.Errorf("task run %s was expected to be in TaskRunSucceed state \n%v \ntaskrun logs error: \n%v \ntaskrun events error: \n%v", trname, err, logsErr, eventError)
 			} else {
-				printMsg = fmt.Sprintf("task run %s was expected to be in TaskRunSucceed state \n%v \ntaskrun logs error: \n%v \ntaskrun events: \n%v", trname, err, logsErr, events)
+				testsuit.T.Errorf("task run %s was expected to be in TaskRunSucceed state \n%v \ntaskrun logs error: \n%v \ntaskrun events: \n%v", trname, err, logsErr, events)
 			}
 		} else {
 			if eventError != nil {
-				printMsg = fmt.Sprintf("task run %s was expected to be in TaskRunSucceed state \n%v \ntaskrun logs: \n%v \ntaskrun events error: \n%v", trname, err, buf.String(), eventError)
+				testsuit.T.Errorf("task run %s was expected to be in TaskRunSucceed state \n%v \ntaskrun logs: \n%v \ntaskrun events error: \n%v", trname, err, buf.String(), eventError)
 			} else {
-				printMsg = fmt.Sprintf("task run %s was expected to be in TaskRunSucceed state \n%v \ntaskrun logs: \n%v \ntaskrun events: \n%v", trname, err, buf.String(), events)
+				testsuit.T.Errorf("task run %s was expected to be in TaskRunSucceed state \n%v \ntaskrun logs: \n%v \ntaskrun events: \n%v", trname, err, buf.String(), events)
 			}
 		}
-		testsuit.T.Errorf(printMsg)
 	}
 }
 

--- a/pkg/tkn/tkn.go
+++ b/pkg/tkn/tkn.go
@@ -49,7 +49,7 @@ func AssertComponentVersion(version string, component string) {
 
 	actualVersion = strings.Trim(actualVersion, "\n")
 	if !strings.Contains(actualVersion, version) {
-		testsuit.T.Errorf("The " + component + " has an unexpected version: " + actualVersion + ", expected: " + version)
+		testsuit.T.Errorf("The %s has an unexpected version: %s, expected: %s", component, actualVersion, version)
 	}
 }
 
@@ -58,7 +58,7 @@ func DownloadCLIFromCluster() {
 	var cliDownloadURL = cmd.MustSucceed("oc", "get", "consoleclidownloads", "tkn", "-o", "jsonpath={.spec.links[?(@.text==\"Download tkn and tkn-pac for "+architecture+"\")].href}").Stdout()
 	result := cmd.MustSuccedIncreasedTimeout(time.Minute*10, "curl", "-o", "/tmp/tkn-binary.tar.gz", "-k", cliDownloadURL)
 	if result.ExitCode != 0 {
-		testsuit.T.Errorf(result.Stderr())
+		testsuit.T.Errorf("%s", result.Stderr())
 	}
 	cmd.MustSucceed("tar", "-xf", "/tmp/tkn-binary.tar.gz", "-C", "/tmp")
 }
@@ -71,7 +71,7 @@ func AssertClientVersion(binary string) {
 		commandResult = cmd.MustSucceed("/tmp/tkn-pac", "version").Stdout()
 		expectedVersion := os.Getenv("PAC_VERSION")
 		if !strings.Contains(commandResult, expectedVersion) {
-			testsuit.T.Errorf("tkn-pac has an unexpected version: " + commandResult + ". Expected: " + expectedVersion)
+			testsuit.T.Errorf("tkn-pac has an unexpected version: %s. Expected: %s", commandResult, expectedVersion)
 		}
 
 	case "tkn":
@@ -82,7 +82,7 @@ func AssertClientVersion(binary string) {
 			if strings.Contains(splittedCommandResult[i], "Client") {
 				if !strings.Contains(splittedCommandResult[i], expectedVersion) {
 					unexpectedVersion = splittedCommandResult[i]
-					testsuit.T.Errorf("tkn client has an unexpected version: " + unexpectedVersion + " Expected: " + expectedVersion)
+					testsuit.T.Errorf("tkn client has an unexpected version: %s. Expected: %s", unexpectedVersion, expectedVersion)
 				}
 			}
 		}
@@ -96,7 +96,7 @@ func AssertClientVersion(binary string) {
 			if strings.Contains(splittedCommandResult[i], components[i]) {
 				if !strings.Contains(splittedCommandResult[i], expectedVersions[i]) {
 					unexpectedVersion = splittedCommandResult[i]
-					testsuit.T.Errorf(components[i] + " has an unexpected version: \"" + unexpectedVersion + "\". Expected: " + expectedVersions[i])
+					testsuit.T.Errorf("%s has an unexpected version: %s. Expected: %s", components[i], unexpectedVersion, expectedVersions[i])
 				}
 			}
 		}

--- a/pkg/triggers/triggers.go
+++ b/pkg/triggers/triggers.go
@@ -217,7 +217,7 @@ func AssertElResponse(c *clients.Clients, resp *http.Response, elname, namespace
 	logs := cmd.MustSucceed("oc", "-n", namespace, "logs", "pods/"+sinkPods.Items[0].Name, "--all-containers", "--tail=2").Stdout()
 	if strings.Contains(logs, "error") {
 		testsuit.T.Errorf("Error: sink logs: \n %s", logs)
-		gauge.WriteMessage(fmt.Sprintf("sink logs: \n %s", logs))
+		gauge.WriteMessage("sink logs: \n %s", logs)
 	}
 }
 


### PR DESCRIPTION
It was complaining about issues like these
```
pkg/pipelines/pipelines.go:55:21: printf: non-constant format string in call to (*github.com/getgauge-contrib/gauge-go/testsuit.testingT).Errorf (govet)
                testsuit.T.Errorf(printMsg)
                                  ^
pkg/pipelines/pipelines.go:105:21: printf: non-constant format string in call to (*github.com/getgauge-contrib/gauge-go/testsuit.testingT).Errorf (govet)
                testsuit.T.Errorf(printMsg)
                                  ^
pkg/pipelines/taskrun.go:62:21: printf: non-constant format string in call to (*github.com/getgauge-contrib/gauge-go/testsuit.testingT).Errorf (govet)
                testsuit.T.Errorf(printMsg)
                                  ^
pkg/pipelines/taskrun.go:87:21: printf: non-constant format string in call to (*github.com/getgauge-contrib/gauge-go/testsuit.testingT).Errorf (govet)
                testsuit.T.Errorf(printMsg)
                                  ^
INFO File cache stats: 35 entries of total size 187.7KiB 
INFO Memory: 31 samples, avg is 606.1MB, max is 1408.5MB 
INFO Execution took 2.941501056s
```