### PR TITLE
fix: add GitLab prefix to env variable

### DIFF
--- a/pkg/pac/pac.go
+++ b/pkg/pac/pac.go
@@ -42,8 +42,8 @@ const (
 
 func CreateGitLabSecret() {
 	tokenSecretData := os.Getenv("GITLAB_TOKEN")
-	webhookSecretData := os.Getenv("WEBHOOK_TOKEN")
-	store.PutScenarioData("WEBHOOK_TOKEN", webhookSecretData)
+	webhookSecretData := os.Getenv("GITLAB_WEBHOOK_TOKEN")
+	store.PutScenarioData("GITLAB_WEBHOOK_TOKEN", webhookSecretData)
 	if tokenSecretData == "" && webhookSecretData == "" {
 		testsuit.T.Fail(fmt.Errorf("token for authorization to the GitLab repository was not exported as a system variable"))
 	} else {
@@ -252,7 +252,7 @@ func SetupGitLabProject(client *gitlab.Client) *gitlab.Project {
 	}
 
 	smeeURL := store.GetScenarioData("SMEE_URL")
-	webhookToken := store.GetScenarioData("WEBHOOK_TOKEN")
+	webhookToken := store.GetScenarioData("GITLAB_WEBHOOK_TOKEN")
 
 	project, err := forkProject(client, projectIDOrPath, gitlabGroupNamespace)
 	if err != nil {

--- a/specs/pac/README.md
+++ b/specs/pac/README.md
@@ -10,8 +10,8 @@ Pipelines as code is a project allowing you to define your CI/CD using Tekton Pi
 - Copy the project ID by clicking on three dots in project root directory and`export GITLAB_PROJECT_ID=<ProjectID>`
 - Click on your profile under `preferences` Under `User Settings --> Access tokens`
 - Create a New Personal Access Token and `export GITLAB_TOKEN=<Token>`
-- Create a new Public Group in Gitlab and Copy the only the Group name from URL e.g: From GitLab URL `https://gitlab.com/groups/test324345` Copy only the group name `test324345` and `export GITLAB_GROUP_NAMESPACE=<GroupName>`
-- Enter any WebhookSecret to be used for gitlab webhook `export WEBHOOK_TOKEN=<WebhookSecret>`
+- Create a new Public Group in GitLab and Copy the only the Group name from URL e.g: From GitLab URL `https://gitlab.com/groups/test324345` Copy only the group name `test324345` and `export GITLAB_GROUP_NAMESPACE=<GroupName>`
+- Enter any WebhookSecret to be used for GitLab webhook `export GITLAB_WEBHOOK_TOKEN=<WebhookSecret>`
 
 ## Running PAC E2E tests
 Export the following Env Variables
@@ -19,7 +19,7 @@ Export the following Env Variables
 export GITLAB_TOKEN=<Token>
 export GITLAB_PROJECT_ID=<ProjectID>
 export GITLAB_GROUP_NAMESPACE=<GroupName>
-export WEBHOOK_TOKEN=<WebhookSecret>
+export GITLAB_WEBHOOK_TOKEN=<GitLabWebHookSecret>
 ```
 
 To run pac e2e tests...


### PR DESCRIPTION
`export WEBHOOK_TOKEN` to `export GITLAB_WEBHOOK_TOKEN`