### PR TITLE
installersets for cluster tasks removed

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,16 +80,13 @@ const (
 )
 
 // Name prefixes of installerset
-var TektonInstallersetNamePrefixes [37]string = [37]string{
-	"addon-custom-clustertask",
-	"addon-custom-communityclustertask",
+var TektonInstallersetNamePrefixes [34]string = [34]string{
 	"addon-custom-consolecli",
 	"addon-custom-openshiftconsole",
 	"addon-custom-pipelinestemplate",
 	"addon-custom-resolverstepaction",
 	"addon-custom-resolvertask",
 	"addon-custom-triggersresources",
-	"addon-versioned-clustertasks",
 	"addon-versioned-resolverstepactions",
 	"addon-versioned-resolvertasks",
 	"chain",


### PR DESCRIPTION
Tests for cluster tasks will be removed in separate PR, this PR is just supposed to unblock operator installation