### PR TITLE
cluster resolver tests: precondition to remove projects

### DIFF
--- a/specs/pipelines/cluster-resolvers.spec
+++ b/specs/pipelines/cluster-resolvers.spec
@@ -1,6 +1,11 @@
 PIPELINES-23
 # Cluster resolvers spec
 
+Pre condition:
+  * Delete project "releasetest-tasks"
+  * Delete project "releasetest-pipelines"
+  * Delete project "releasetest-pipelineruns"
+
 ## Checking the functionality of cluster resolvers#1: PIPELINES-23-TC01
 Tags: e2e, sanity
 Component: Resolvers


### PR DESCRIPTION
We are removing projects at the end of test but sometimes it failes in CI and then it's not possible to re-run the tests on the same cluster without first removing projects manually which is annoying.