### PR TITLE
SRVKP-6723 switch release-tests-post-upgrade test from nodejs to golang

### DIFF
--- a/specs/operator/post-upgrade.spec
+++ b/specs/operator/post-upgrade.spec
@@ -36,18 +36,6 @@ Steps:
     |----|-----------------|-------|
     |1   |bitbucket-run    |Failure|
 
-## Verify S2I nodejs pipeline after upgrade: PIPELINES-19-TC02
-Tags: post-upgrade, e2e, clustertasks, non-admin, s2i
-Component: Pipelines
-Level: Integration
-Type: Functional
-Importance: Critical
-
-Steps:
-  * Switch to project "releasetest-upgrade-s2i"
-  * Get tags of the imagestream "nodejs" from namespace "openshift" and store to variable "nodejs-tags"
-  * Start and verify pipeline "s2i-nodejs-pipeline" with param "VERSION" with values stored in variable "nodejs-tags" with workspace "name=source,claimName=shared-pvc"
-
 ## Verify Event listener with TLS after upgrade: PIPELINES-19-TC03
 Tags: post-upgrade, tls, triggers, admin, e2e, sanity
 Component: Triggers
@@ -84,3 +72,15 @@ Steps:
       | S.NO | pipeline_run_name                   | status     | check_label_propagation |
       |------|-------------------------------------|------------|-------------------------|
       | 1    | git-clone-read-private-pipeline-run | successful | no                      |
+    
+## Verify S2I golang pipeline after upgrade: PIPELINES-19-TC05
+Tags: post-upgrade, e2e, clustertasks, non-admin, s2i
+Component: Pipelines
+Level: Integration
+Type: Functional
+Importance: Critical
+
+Steps:
+  * Switch to project "releasetest-upgrade-s2i"
+  * Get tags of the imagestream "golang" from namespace "openshift" and store to variable "golang-tags"
+  * Start and verify pipeline "s2i-go-pipeline" with param "VERSION" with values stored in variable "golang-tags" with workspace "name=source,claimName=shared-pvc"

--- a/specs/operator/pre-upgrade.spec
+++ b/specs/operator/pre-upgrade.spec
@@ -58,22 +58,6 @@ Steps:
     |1   |bitbucket-run    |Failure|
   * Delete "taskrun" named "bitbucket-run"
 
-## Setup S2I nodejs pipeline pre upgrade: PIPELINES-18-TC02
-Tags: pre-upgrade, e2e, clustertasks, non-admin, s2i
-Component: Pipelines
-Level: Integration
-Type: Functional
-Importance: Critical
-
-Steps:
-  * Create project "releasetest-upgrade-s2i"
-  * Verify ServiceAccount "pipeline" exist
-  * Create
-      |S.NO|resource_dir                                          |
-      |----|------------------------------------------------------|
-      |1   |testdata/ecosystem/pipelines/s2i-nodejs.yaml|
-      |2   |testdata/pvc/pvc.yaml                                 |
-
 ## Setup Eventlistener with TLS enabled pre upgrade: PIPELINES-18-TC03
 Tags: pre-upgrade, tls, triggers, admin, e2e, sanity
 Component: Triggers
@@ -127,3 +111,19 @@ Steps:
       |------|-------------------------------------|------------|-------------------------|
       | 1    | git-clone-read-private-pipeline-run | successful | no                      |
   * Delete "pipelinerun" named "git-clone-read-private-pipeline-run"
+
+## Setup S2I golang pipeline pre upgrade: PIPELINES-18-TC05
+Tags: pre-upgrade, e2e, clustertasks, non-admin, s2i
+Component: Pipelines
+Level: Integration
+Type: Functional
+Importance: Critical
+
+Steps:
+  * Create project "releasetest-upgrade-s2i"
+  * Verify ServiceAccount "pipeline" exist
+  * Create
+      |S.NO|resource_dir                                          |
+      |----|------------------------------------------------------|
+      |1   |testdata/ecosystem/pipelines/s2i-go.yaml|
+      |2   |testdata/pvc/pvc.yaml                                 |


### PR DESCRIPTION
Tested pre-upgrade & post-upgrade scenarios with changes made
![Screenshot From 2025-01-24 13-25-21](https://github.com/user-attachments/assets/7cbb0735-04c9-4e1e-bd49-bfdc764a2246)
https://console-openshift-console.apps.cicd.ospqa.com/k8s/ns/smanthin/tekton.dev~v1~PipelineRun/upgrade-tests-jc21en/logs?taskName=release-tests-post-upgrade