### PR TITLE
[SRVKP-6773] add statefuslet enablment to QA tests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,7 +95,7 @@ var TektonInstallersetNamePrefixes [34]string = [34]string{
 	"openshiftpipelinesascode-main-deployment",
 	"openshiftpipelinesascode-main-static",
 	"openshiftpipelinesascode-post",
-	"pipeline-main-deployment",
+	"pipeline-main-statefulset",
 	"pipeline-main-static",
 	"pipeline-post",
 	"pipeline-pre",

--- a/pkg/statefulset/statefulset.go
+++ b/pkg/statefulset/statefulset.go
@@ -1,0 +1,63 @@
+package statefulset
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/getgauge-contrib/gauge-go/testsuit"
+	"github.com/openshift-pipelines/release-tests/pkg/clients"
+	"github.com/openshift-pipelines/release-tests/pkg/config"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func ValidateStatefulSetDeployment(cs *clients.Clients, deploymentName string) {
+	labelSelector := "app.kubernetes.io/part-of=tekton-pipelines"
+	listOptions := metav1.ListOptions{LabelSelector: labelSelector}
+
+	log.Printf("Starting validation for StatefulSet deployment: %s in namespace: %s", deploymentName, config.TargetNamespace)
+
+	waitErr := wait.PollUntilContextTimeout(context.TODO(), config.APIRetry, config.APITimeout, true, func(ctx context.Context) (bool, error) {
+		stsList, err := cs.KubeClient.Kube.AppsV1().StatefulSets(config.TargetNamespace).List(context.TODO(), listOptions)
+		if err != nil {
+			log.Printf("Error listing StatefulSets: %v", err)
+			return false, fmt.Errorf("failed to list StatefulSets: %v", err)
+		}
+
+		log.Printf("Found %d StatefulSets in namespace %s", len(stsList.Items), config.TargetNamespace)
+
+		for _, sts := range stsList.Items {
+			if sts.Name == deploymentName {
+				log.Printf("Found StatefulSet: %s", sts.Name)
+				isAvailable, err := IsStatefulSetAvailable(&sts)
+				if err != nil {
+					log.Printf("Error checking availability of StatefulSet %s: %v", sts.Name, err)
+					return false, err
+				}
+				if isAvailable {
+					log.Printf("StatefulSet %s is available and ready", sts.Name)
+					return true, nil
+				} else {
+					log.Printf("StatefulSet %s is not ready yet", sts.Name)
+					return false, nil
+				}
+			}
+		}
+		log.Printf("StatefulSet %s not found yet. Continuing to wait...", deploymentName)
+		return false, nil
+	})
+
+	if waitErr != nil {
+		testsuit.T.Fatalf("StatefulSet %s was not found or not available within 5 minutes in the namespace %q: %v",
+			deploymentName, config.TargetNamespace, waitErr)
+	}
+}
+
+func IsStatefulSetAvailable(sts *appsv1.StatefulSet) (bool, error) {
+	if sts.Status.ReadyReplicas == *sts.Spec.Replicas {
+		return true, nil
+	}
+	return false, nil
+}

--- a/specs/olm.spec
+++ b/specs/olm.spec
@@ -30,11 +30,13 @@ Steps:
   * Configure GitHub token for git resolver in TektonConfig
   * Configure the bundles resolver
   * Enable console plugin
-  * Validate pipelines deployment
+  * Enable statefulset in tektonconfig
   * Validate triggers deployment
   * Validate PAC deployment
   * Validate chains deployment
   * Validate hub deployment
+  * Validate "tekton-pipelines-controller" statefulset deployment
+  * Validate "tekton-pipelines-remote-resolvers" statefulset deployment
   * Validate tkn server cli deployment
   * Validate console plugin deployment
   * Ensure that Tekton Results is ready

--- a/steps/cli/oc.go
+++ b/steps/cli/oc.go
@@ -235,3 +235,8 @@ var _ = gauge.Step("Enable console plugin", func() {
 
 	oc.EnableConsolePlugin()
 })
+
+var _ = gauge.Step("Enable statefulset in tektonconfig", func() {
+	patch_data := "{\"spec\":{\"pipeline\":{\"performance\":{\"disable-ha\":false,\"statefulset-ordinals\":true,\"replicas\":2,\"buckets\":2}}}}"
+	oc.UpdateTektonConfig(patch_data)
+})

--- a/steps/olm/operator.go
+++ b/steps/olm/operator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift-pipelines/release-tests/pkg/olm"
 	"github.com/openshift-pipelines/release-tests/pkg/openshift"
 	"github.com/openshift-pipelines/release-tests/pkg/operator"
+	"github.com/openshift-pipelines/release-tests/pkg/statefulset"
 	"github.com/openshift-pipelines/release-tests/pkg/store"
 	"github.com/openshift-pipelines/release-tests/pkg/tkn"
 )
@@ -68,6 +69,11 @@ var _ = gauge.Step("Validate hub deployment", func() {
 
 var _ = gauge.Step("Validate manual approval gate deployment", func() {
 	operator.ValidateManualApprovalGateDeployments(store.Clients(), store.GetCRNames())
+})
+
+var _ = gauge.Step("Validate <deploymentName> statefulset deployment", func(deploymentName string) {
+	log.Printf("Validating statefulset %v deployment\n", deploymentName)
+	statefulset.ValidateStatefulSetDeployment(store.Clients(), deploymentName)
 })
 
 var _ = gauge.Step("Uninstall Operator", func() {


### PR DESCRIPTION
Changes added:
Added package statefulset for sts validations
Enable stateful-set in tektonconfig
Validate  stateful-set deployment


Changes removed:
* Validate pipelines deployment
As we are now validating "tekton-pipelines-controller" to be run as stateful-set deployment

![Screenshot From 2025-01-29 12-03-04](https://github.com/user-attachments/assets/678b21f9-c04a-42db-a358-5caeef9e1bb4)
