### PR TITLE
Fix linter issues before upgrading to v2

### DIFF
--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -76,17 +76,17 @@ func NewClients(configPath string, clusterName, namespace string) (*Clients, err
 
 	clients.Dynamic, err = dynamic.NewForConfig(clients.KubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create dynamic clients from config file at %s: %s", configPath, err)
+		return nil, fmt.Errorf("failed to create dynamic clients from config file at %s: %s", configPath, err)
 	}
 
 	clients.Operator, err = newTektonOperatorAlphaClients(clients.KubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create Operator v1alpha1 clients from config file at %s: %s", configPath, err)
+		return nil, fmt.Errorf("failed to create Operator v1alpha1 clients from config file at %s: %s", configPath, err)
 	}
 
 	clients.OLM, err = olmversioned.NewForConfig(clients.KubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create olm clients from config file at %s: %s", configPath, err)
+		return nil, fmt.Errorf("failed to create olm clients from config file at %s: %s", configPath, err)
 	}
 
 	clients.Tekton, err = pversioned.NewForConfig(clients.KubeConfig)
@@ -95,17 +95,17 @@ func NewClients(configPath string, clusterName, namespace string) (*Clients, err
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create resource clientset from config file at %s: %s", configPath, err)
+		return nil, fmt.Errorf("failed to create resource clientset from config file at %s: %s", configPath, err)
 	}
 
 	clients.TriggersClient, err = triggersclientset.NewForConfig(clients.KubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create triggers clientset from config file at %s: %s", configPath, err)
+		return nil, fmt.Errorf("failed to create triggers clientset from config file at %s: %s", configPath, err)
 	}
 
 	clients.PacClientset, err = pacclientset.NewForConfig(clients.KubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create pac clientset from config file at %s: %s", configPath, err)
+		return nil, fmt.Errorf("failed to create pac clientset from config file at %s: %s", configPath, err)
 	}
 	clients.NewClientSet(namespace)
 	return clients, nil

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -23,11 +23,11 @@ type testsuitAdaptor struct{}
 var _ assert.TestingT = (*testsuitAdaptor)(nil)
 
 func (ta testsuitAdaptor) Fail() {
-	testsuit.T.Fail(fmt.Errorf("Step failed execute"))
+	testsuit.T.Fail(fmt.Errorf("step failed execute"))
 }
 
 func (ta testsuitAdaptor) FailNow() {
-	testsuit.T.Fail(fmt.Errorf("Step failed to execute"))
+	testsuit.T.Fail(fmt.Errorf("step failed to execute"))
 }
 
 func (ta testsuitAdaptor) Log(args ...interface{}) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -219,7 +219,7 @@ func Read(path string) ([]byte, error) {
 func TempDir() (string, error) {
 	tmp := filepath.Join(Dir(), "..", "tmp")
 	if _, err := os.Stat(tmp); os.IsNotExist(err) {
-		err := os.Mkdir(tmp, 0755)
+		err := os.Mkdir(tmp, 0750)
 		return tmp, err
 	}
 	return tmp, nil

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -400,7 +400,7 @@ func AssertCronjobPresent(c *clients.Clients, cronJobName, namespace string) {
 		return false, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: cronjob with prefix %v present in namespace %v, Actual: cronjob with prefix %v not present in namespace %v", cronJobName, namespace, cronJobName, namespace))
+		testsuit.T.Fail(fmt.Errorf("expected: cronjob with prefix %v present in namespace %v, Actual: cronjob with prefix %v not present in namespace %v", cronJobName, namespace, cronJobName, namespace))
 	}
 	log.Printf("Cronjob with prefix %v is present in namespace %v", cronJobName, namespace)
 }
@@ -420,7 +420,7 @@ func AssertCronjobNotPresent(c *clients.Clients, cronJobName, namespace string) 
 		return true, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: cronjob with prefix %v present in namespace %v, Actual: cronjob with prefix %v not present in namespace %v", cronJobName, namespace, cronJobName, namespace))
+		testsuit.T.Fail(fmt.Errorf("expected: cronjob with prefix %v present in namespace %v, Actual: cronjob with prefix %v not present in namespace %v", cronJobName, namespace, cronJobName, namespace))
 	}
 	log.Printf("Cronjob with prefix %v is present in namespace %v", cronJobName, namespace)
 }
@@ -429,7 +429,7 @@ func ValidateTektonInstallersetStatus(c *clients.Clients) {
 	tis, err := c.Operator.TektonInstallerSets().List(c.Ctx, metav1.ListOptions{})
 	failedInstallersets := make([]string, 0)
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Error getting tektoninstallersets: %v", err))
+		testsuit.T.Fail(fmt.Errorf("error getting tektoninstallersets: %v", err))
 	}
 
 	for _, is := range tis.Items {
@@ -440,7 +440,7 @@ func ValidateTektonInstallersetStatus(c *clients.Clients) {
 	}
 
 	if len(failedInstallersets) > 0 {
-		testsuit.T.Fail(fmt.Errorf("The installersets %s is/are not in ready status", strings.Join(failedInstallersets, ",")))
+		testsuit.T.Fail(fmt.Errorf("the installersets %s is/are not in ready status", strings.Join(failedInstallersets, ",")))
 	}
 	log.Print("All the installersets are in ready state")
 }
@@ -448,7 +448,7 @@ func ValidateTektonInstallersetStatus(c *clients.Clients) {
 func ValidateTektonInstallersetNames(c *clients.Clients) {
 	tis, err := c.Operator.TektonInstallerSets().List(c.Ctx, metav1.ListOptions{})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Error getting tektoninstallersets: %v", err))
+		testsuit.T.Fail(fmt.Errorf("error getting tektoninstallersets: %v", err))
 	}
 	missingInstallersets := make([]string, 0)
 	for _, isp := range config.TektonInstallersetNamePrefixes {
@@ -479,7 +479,7 @@ func ValidateTektonInstallersetNames(c *clients.Clients) {
 	}
 
 	if len(missingInstallersets) > 0 {
-		testsuit.T.Fail(fmt.Errorf("Installersets with prefix %s is not found", strings.Join(missingInstallersets, ",")))
+		testsuit.T.Fail(fmt.Errorf("installersets with prefix %s is not found", strings.Join(missingInstallersets, ",")))
 	}
 }
 

--- a/pkg/oc/oc.go
+++ b/pkg/oc/oc.go
@@ -11,13 +11,12 @@ import (
 	"github.com/getgauge-contrib/gauge-go/testsuit"
 	"github.com/openshift-pipelines/release-tests/pkg/cmd"
 	"github.com/openshift-pipelines/release-tests/pkg/config"
-	resource "github.com/openshift-pipelines/release-tests/pkg/config"
 	"github.com/openshift-pipelines/release-tests/pkg/store"
 )
 
 // Create resources using oc command
 func Create(path_dir, namespace string) {
-	log.Printf("output: %s\n", cmd.MustSucceed("oc", "create", "-f", resource.Path(path_dir), "-n", namespace).Stdout())
+	log.Printf("output: %s\n", cmd.MustSucceed("oc", "create", "-f", config.Path(path_dir), "-n", namespace).Stdout())
 }
 
 // Create resources using remote path using oc command
@@ -26,7 +25,7 @@ func CreateRemote(remote_path, namespace string) {
 }
 
 func Apply(path_dir, namespace string) {
-	log.Printf("output: %s\n", cmd.MustSucceed("oc", "apply", "-f", resource.Path(path_dir), "-n", namespace).Stdout())
+	log.Printf("output: %s\n", cmd.MustSucceed("oc", "apply", "-f", config.Path(path_dir), "-n", namespace).Stdout())
 }
 
 // Delete resources using oc command
@@ -34,7 +33,7 @@ func Delete(path_dir, namespace string) {
 	// Tekton Results sets a finalizer that prevent resource removal for some time
 	// see parameters "store_deadline" and "forward_buffer"
 	// by default, it waits at least 150 seconds
-	log.Printf("output: %s\n", cmd.MustSuccedIncreasedTimeout(time.Second*300, "oc", "delete", "-f", resource.Path(path_dir), "-n", namespace).Stdout())
+	log.Printf("output: %s\n", cmd.MustSuccedIncreasedTimeout(time.Second*300, "oc", "delete", "-f", config.Path(path_dir), "-n", namespace).Stdout())
 }
 
 // CreateNewProject Helps you to create new project

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -85,7 +85,7 @@ func ValidateHubDeployments(cs *clients.Clients, rnames utils.ResourceNames) {
 
 func ValidateManualApprovalGateDeployments(cs *clients.Clients, rnames utils.ResourceNames) {
 	if _, err := approvalgate.EnsureManualApprovalGateExists(cs.ManualApprovalGate(), rnames); err != nil {
-		testsuit.T.Fail(fmt.Errorf("Manual approval gate doesn't exists\n %v", err))
+		testsuit.T.Fail(fmt.Errorf("manual approval gate doesn't exists\n %v", err))
 	}
 	k8s.ValidateDeployments(cs, rnames.TargetNamespace,
 		config.MAGController, config.MAGWebHook)

--- a/pkg/operator/rbac.go
+++ b/pkg/operator/rbac.go
@@ -28,7 +28,7 @@ func AssertServiceAccountPresent(clients *clients.Clients, ns, targetSA string) 
 		return false, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: Service account %v present in the namespace %v, Actual: Service account %v not present in the namespace %v, Error: %v", targetSA, ns, targetSA, ns, err))
+		testsuit.T.Fail(fmt.Errorf("expected: Service account %v present in the namespace %v, Actual: Service account %v not present in the namespace %v, Error: %v", targetSA, ns, targetSA, ns, err))
 	}
 }
 func AssertRoleBindingPresent(clients *clients.Clients, ns, roleBindingName string) {
@@ -46,7 +46,7 @@ func AssertRoleBindingPresent(clients *clients.Clients, ns, roleBindingName stri
 		return false, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: Rolebinding %v present in the namespace %v, Actual: Rolebinding %v not present in the namespace %v, Error: %v", roleBindingName, ns, roleBindingName, ns, err))
+		testsuit.T.Fail(fmt.Errorf("expected: Rolebinding %v present in the namespace %v, Actual: Rolebinding %v not present in the namespace %v, Error: %v", roleBindingName, ns, roleBindingName, ns, err))
 	}
 }
 
@@ -65,7 +65,7 @@ func AssertConfigMapPresent(clients *clients.Clients, ns, configMapName string) 
 		return false, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: Configmap %v present in the namespace %v, Actual: Configmap %v not present in the namespace %v, Error: %v", configMapName, ns, configMapName, ns, err))
+		testsuit.T.Fail(fmt.Errorf("expected: Configmap %v present in the namespace %v, Actual: Configmap %v not present in the namespace %v, Error: %v", configMapName, ns, configMapName, ns, err))
 	}
 }
 
@@ -84,7 +84,7 @@ func AssertClusterRolePresent(clients *clients.Clients, clusterRoleName string) 
 		return false, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: Clusterrole %v present, Actual: Clusterrole %v not present, Error: %v", clusterRoleName, clusterRoleName, err))
+		testsuit.T.Fail(fmt.Errorf("expected: Clusterrole %v present, Actual: Clusterrole %v not present, Error: %v", clusterRoleName, clusterRoleName, err))
 	}
 }
 
@@ -103,7 +103,7 @@ func AssertServiceAccountNotPresent(clients *clients.Clients, ns, targetSA strin
 		return true, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: Service account %v not present in the namespace %v, Actual: Service account %v is present in the namespace %v, Error: %v", targetSA, ns, targetSA, ns, err))
+		testsuit.T.Fail(fmt.Errorf("expected: Service account %v not present in the namespace %v, Actual: Service account %v is present in the namespace %v, Error: %v", targetSA, ns, targetSA, ns, err))
 	}
 }
 
@@ -122,7 +122,7 @@ func AssertRoleBindingNotPresent(clients *clients.Clients, ns, roleBindingName s
 		return true, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: Rolebinding %v not present in the namespace %v, Actual: Rolebinding %v present in the namespace %v, Error: %v", roleBindingName, ns, roleBindingName, ns, err))
+		testsuit.T.Fail(fmt.Errorf("expected: Rolebinding %v not present in the namespace %v, Actual: Rolebinding %v present in the namespace %v, Error: %v", roleBindingName, ns, roleBindingName, ns, err))
 	}
 }
 
@@ -141,7 +141,7 @@ func AssertConfigMapNotPresent(clients *clients.Clients, ns, configMapName strin
 		return true, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: Configmap %v not present in the namespace %v, Expected: Configmap %v present in the namespace %v, Error: %v", configMapName, ns, configMapName, ns, err))
+		testsuit.T.Fail(fmt.Errorf("expected: Configmap %v not present in the namespace %v, Expected: Configmap %v present in the namespace %v, Error: %v", configMapName, ns, configMapName, ns, err))
 	}
 }
 
@@ -160,7 +160,7 @@ func AssertClusterRoleNotPresent(clients *clients.Clients, clusterRoleName strin
 		return true, err
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected, Clusterrole %v not present, Actual: Clusterrole %v present, Error: %v", clusterRoleName, clusterRoleName, err))
+		testsuit.T.Fail(fmt.Errorf("expected, Clusterrole %v not present, Actual: Clusterrole %v present, Error: %v", clusterRoleName, clusterRoleName, err))
 	}
 }
 
@@ -180,7 +180,7 @@ func AssertSCCPresent(clients *clients.Clients, sccName string) {
 		return false, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: security context constraint %q present, Actual: security context constraint %q not present , Error: %v", sccName, sccName, err))
+		testsuit.T.Fail(fmt.Errorf("expected: security context constraint %q present, Actual: security context constraint %q not present , Error: %v", sccName, sccName, err))
 	}
 }
 
@@ -200,6 +200,6 @@ func AssertSCCNotPresent(clients *clients.Clients, sccName string) {
 		return true, err
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Expected: security context constraint %q not present, Actual: security context constraint %q present, Error: %v", sccName, sccName, err))
+		testsuit.T.Fail(fmt.Errorf("expected: security context constraint %q not present, Actual: security context constraint %q present, Error: %v", sccName, sccName, err))
 	}
 }

--- a/pkg/operator/tektonaddons.go
+++ b/pkg/operator/tektonaddons.go
@@ -127,7 +127,7 @@ func TektonAddonCRDelete(clients *clients.Clients, crNames utils.ResourceNames) 
 		return false, err
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Timed out waiting on TektonAddon to delete, Error: %v", err))
+		testsuit.T.Fail(fmt.Errorf("timed out waiting on TektonAddon to delete, Error: %v", err))
 	}
 
 	err = verifyNoTektonAddonCR(clients)
@@ -142,7 +142,7 @@ func verifyNoTektonAddonCR(clients *clients.Clients) error {
 		return err
 	}
 	if len(addons.Items) > 0 {
-		return errors.New("Unable to verify cluster-scoped resources are deleted if any TektonAddon exists")
+		return errors.New("unable to verify cluster-scoped resources are deleted if any TektonAddon exists")
 	}
 	return nil
 }

--- a/pkg/operator/tektonchains.go
+++ b/pkg/operator/tektonchains.go
@@ -175,8 +175,8 @@ func CreateFileWithCosignPubKey() {
 	if err != nil {
 		testsuit.T.Errorf("Error decoding base64")
 	}
-	filepath := filepath.Join(publicKeyPath, "cosign.pub")
-	file, err := os.Create(filepath)
+	fullPath := filepath.Join(publicKeyPath, "cosign.pub")
+	file, err := os.Create(filepath.Clean(fullPath))
 	if err != nil {
 		testsuit.T.Errorf("Error creating file")
 	}
@@ -195,7 +195,10 @@ func CreateSigningSecretForTektonChains() {
 		chainsPassword = os.Getenv("COSIGN_PASSWORD")
 		cmd.MustSucceed("oc", "create", "secret", "generic", "signing-secrets", "--from-literal=cosign.key="+chainsPrivateKey, "--from-literal=cosign.password="+chainsPassword, "--from-literal=cosign.pub="+chainsPublicKey, "--namespace", "openshift-pipelines")
 	} else {
-		os.Setenv("COSIGN_PASSWORD", "chainstest")
+		err := os.Setenv("COSIGN_PASSWORD", "chainstest")
+		if err != nil {
+			testsuit.T.Errorf("Error setting environment variable COSIGN_PASSWORD")
+		}
 		cmd.MustSucceed("cosign", "generate-key-pair", "k8s://openshift-pipelines/signing-secrets")
 	}
 }

--- a/pkg/operator/tektonchains.go
+++ b/pkg/operator/tektonchains.go
@@ -30,7 +30,6 @@ import (
 	"github.com/getgauge-contrib/gauge-go/testsuit"
 	"github.com/openshift-pipelines/release-tests/pkg/cmd"
 	"github.com/openshift-pipelines/release-tests/pkg/config"
-	resource "github.com/openshift-pipelines/release-tests/pkg/config"
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	chainv1alpha "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 	"github.com/tektoncd/operator/test/utils"
@@ -41,7 +40,7 @@ import (
 
 // "quay.io/openshift-pipeline/chainstest"
 var repo string = os.Getenv("CHAINS_REPOSITORY")
-var publicKeyPath = resource.Path("testdata/chains/key")
+var publicKeyPath = config.Path("testdata/chains/key")
 
 func EnsureTektonChainsExists(clients chainv1alpha.TektonChainInterface, names utils.ResourceNames) (*v1alpha1.TektonChain, error) {
 	ks, err := clients.Get(context.TODO(), names.TektonChain, metav1.GetOptions{})
@@ -77,7 +76,7 @@ func VerifySignature(resourceType string) {
 		testsuit.T.Errorf("Annotation chains.tekton.dev/signed is set to %s", isSigned)
 	}
 	if len(signature) == 0 {
-		testsuit.T.Fail(fmt.Errorf("Annotation chains.tekton.dev/signature-%s-%s is not set", resourceType, resourceUID))
+		testsuit.T.Fail(fmt.Errorf("annotation chains.tekton.dev/signature-%s-%s is not set", resourceType, resourceUID))
 	}
 
 	// Decode the signature

--- a/pkg/operator/tektonchains.go
+++ b/pkg/operator/tektonchains.go
@@ -99,7 +99,7 @@ func VerifySignature(resourceType string) {
 }
 
 func StartKanikoTask() {
-	var tag string = time.Now().Format("060102150405")
+	var tag = time.Now().Format("060102150405")
 	cmd.MustSucceed("oc", "secrets", "link", "pipeline", "chains-image-registry-credentials", "--for=pull,mount")
 	image := fmt.Sprintf("IMAGE=%s:%s", repo, tag)
 	cmd.MustSucceed("opc", "task", "start", "--param", image, "--use-param-defaults", "--workspace", "name=source,claimName=chains-pvc", "--workspace", "name=dockerconfig,secret=chains-image-registry-credentials", "kaniko-chains")

--- a/pkg/operator/tektonchains.go
+++ b/pkg/operator/tektonchains.go
@@ -89,6 +89,7 @@ func VerifySignature(resourceType string) {
 	if err != nil {
 		testsuit.T.Errorf("Error creating file")
 	}
+	//nolint:errcheck
 	defer file.Close()
 	_, err = file.WriteString(string(decodedSignature))
 	if err != nil {
@@ -180,6 +181,7 @@ func CreateFileWithCosignPubKey() {
 	if err != nil {
 		testsuit.T.Errorf("Error creating file")
 	}
+	//nolint:errcheck
 	defer file.Close()
 	_, err = file.WriteString(string(decodedPublicKey))
 	if err != nil {

--- a/pkg/operator/tektonconfig.go
+++ b/pkg/operator/tektonconfig.go
@@ -123,7 +123,7 @@ func TektonConfigCRDelete(clients *clients.Clients, crNames utils.ResourceNames)
 		return false, err
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Timed out waiting on TektonConfigCR to delete, Error: %v", err))
+		testsuit.T.Fail(fmt.Errorf("timed out waiting on TektonConfigCR to delete, Error: %v", err))
 	}
 	err = verifyNoTektonConfigCR(clients)
 	if err != nil {
@@ -137,7 +137,7 @@ func verifyNoTektonConfigCR(clients *clients.Clients) error {
 		return err
 	}
 	if len(configs.Items) > 0 {
-		return errors.New("Unable to verify cluster-scoped resources are deleted if any TektonConfig exists")
+		return errors.New("unable to verify cluster-scoped resources are deleted if any TektonConfig exists")
 	}
 	return nil
 }

--- a/pkg/operator/tektonpipelines.go
+++ b/pkg/operator/tektonpipelines.go
@@ -104,7 +104,7 @@ func TektonPipelineCRDelete(clients *clients.Clients, crNames utils.ResourceName
 		return false, err
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Timed out waiting on TektonPipeline to delete, Error: %v", err))
+		testsuit.T.Fail(fmt.Errorf("timed out waiting on TektonPipeline to delete, Error: %v", err))
 	}
 	if err := verifyNoTektonPipelineCR(clients); err != nil {
 		testsuit.T.Fail(err)
@@ -117,7 +117,7 @@ func verifyNoTektonPipelineCR(clients *clients.Clients) error {
 		return err
 	}
 	if len(pipelines.Items) > 0 {
-		return errors.New("Unable to verify cluster-scoped resources are deleted if any TektonPipeline exists")
+		return errors.New("unable to verify cluster-scoped resources are deleted if any TektonPipeline exists")
 	}
 	return nil
 }

--- a/pkg/operator/tektonresults.go
+++ b/pkg/operator/tektonresults.go
@@ -94,7 +94,7 @@ func VerifyResultsAnnotationStored(resourceType string) {
 	})
 
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Annotation 'results.tekton.dev/stored' is not true: %v", err))
+		testsuit.T.Fail(fmt.Errorf("annotation 'results.tekton.dev/stored' is not true: %v", err))
 	}
 }
 
@@ -105,7 +105,7 @@ func VerifyResultsLogs(resourceType string) {
 	results_api = GetResultsApi()
 
 	if record_uuid == "" {
-		testsuit.T.Fail(fmt.Errorf("Annotation results.tekton.dev/record is not set"))
+		testsuit.T.Fail(fmt.Errorf("annotation results.tekton.dev/record is not set"))
 	}
 
 	var resultsJsonData string = cmd.MustSucceed("opc", "results", "logs", "get", "--insecure", "--addr", results_api, record_uuid).Stdout()

--- a/pkg/operator/tektonresults.go
+++ b/pkg/operator/tektonresults.go
@@ -20,7 +20,7 @@ import (
 )
 
 func CreateSecretsForTektonResults() {
-	var password string = cmd.MustSucceed("openssl", "rand", "-base64", "20").Stdout()
+	var password = cmd.MustSucceed("openssl", "rand", "-base64", "20").Stdout()
 	password = strings.ReplaceAll(password, "\n", "")
 	cmd.MustSucceed("oc", "create", "secret", "-n", "openshift-pipelines", "generic", "tekton-results-postgres", "--from-literal=POSTGRES_USER=result", "--from-literal=POSTGRES_PASSWORD="+password)
 	// generating tls certificate
@@ -38,15 +38,15 @@ func CreateResultsRoute() {
 }
 
 func GetResultsApi() string {
-	var results_api string = cmd.MustSucceed("oc", "get", "route", "tekton-results-api-service", "-n", "openshift-pipelines", "--no-headers", "-o", "custom-columns=:spec.host").Stdout() + ":443"
+	var results_api = cmd.MustSucceed("oc", "get", "route", "tekton-results-api-service", "-n", "openshift-pipelines", "--no-headers", "-o", "custom-columns=:spec.host").Stdout() + ":443"
 	results_api = strings.ReplaceAll(results_api, "\n", "")
 	return results_api
 }
 
 func GetResultsAnnotations(resourceType string) (string, string, string) {
-	var result_uuid string = cmd.MustSucceed("opc", resourceType, "describe", "--last", "-o", "jsonpath='{.metadata.annotations.results\\.tekton\\.dev/result}'").Stdout()
-	var record_uuid string = cmd.MustSucceed("opc", resourceType, "describe", "--last", "-o", "jsonpath='{.metadata.annotations.results\\.tekton\\.dev/record}'").Stdout()
-	var stored string = cmd.MustSucceed("opc", resourceType, "describe", "--last", "-o", "jsonpath='{.metadata.annotations.results\\.tekton\\.dev/stored}'").Stdout()
+	var result_uuid = cmd.MustSucceed("opc", resourceType, "describe", "--last", "-o", "jsonpath='{.metadata.annotations.results\\.tekton\\.dev/result}'").Stdout()
+	var record_uuid = cmd.MustSucceed("opc", resourceType, "describe", "--last", "-o", "jsonpath='{.metadata.annotations.results\\.tekton\\.dev/record}'").Stdout()
+	var stored = cmd.MustSucceed("opc", resourceType, "describe", "--last", "-o", "jsonpath='{.metadata.annotations.results\\.tekton\\.dev/stored}'").Stdout()
 	record_uuid = strings.ReplaceAll(record_uuid, "'", "")
 	result_uuid = strings.ReplaceAll(result_uuid, "'", "")
 	stored = strings.ReplaceAll(stored, "'", "")
@@ -108,7 +108,7 @@ func VerifyResultsLogs(resourceType string) {
 		testsuit.T.Fail(fmt.Errorf("annotation results.tekton.dev/record is not set"))
 	}
 
-	var resultsJsonData string = cmd.MustSucceed("opc", "results", "logs", "get", "--insecure", "--addr", results_api, record_uuid).Stdout()
+	var resultsJsonData = cmd.MustSucceed("opc", "results", "logs", "get", "--insecure", "--addr", results_api, record_uuid).Stdout()
 	if strings.Contains(resultsJsonData, "record not found") {
 		testsuit.T.Errorf("Results log not found")
 	} else {
@@ -136,7 +136,7 @@ func VerifyResultsRecords(resourceType string) {
 	var results_api string
 	_, record_uuid, _ = GetResultsAnnotations(resourceType)
 	results_api = GetResultsApi()
-	var results_record string = cmd.MustSucceed("opc", "results", "records", "get", "--insecure", "--addr", results_api, record_uuid).Stdout()
+	var results_record = cmd.MustSucceed("opc", "results", "records", "get", "--insecure", "--addr", results_api, record_uuid).Stdout()
 	if strings.Contains(results_record, "record not found") {
 		testsuit.T.Errorf("Results record not found")
 	} else {

--- a/pkg/operator/tektontriggers.go
+++ b/pkg/operator/tektontriggers.go
@@ -101,7 +101,7 @@ func TektonTriggerCRDelete(clients *clients.Clients, crNames utils.ResourceNames
 		return false, err
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Timed out waiting on TektonTrigger to delete, Error: %v", err))
+		testsuit.T.Fail(fmt.Errorf("timed out waiting on TektonTrigger to delete, Error: %v", err))
 	}
 
 	if err := verifyNoTektonTriggerCR(clients); err != nil {
@@ -115,7 +115,7 @@ func verifyNoTektonTriggerCR(clients *clients.Clients) error {
 		return err
 	}
 	if len(triggers.Items) > 0 {
-		return errors.New("Unable to verify cluster-scoped resources are deleted if any TektonTrigger exists")
+		return errors.New("unable to verify cluster-scoped resources are deleted if any TektonTrigger exists")
 	}
 	return nil
 }

--- a/pkg/pac/pac.go
+++ b/pkg/pac/pac.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -412,7 +413,7 @@ func GeneratePipelineRunYaml(eventType, branch string) {
 		testsuit.T.Fail(fmt.Errorf("failed to generate pipelinerun: %v", err))
 	}
 
-	fileContent, err := os.ReadFile(fileName)
+	fileContent, err := os.ReadFile(filepath.Clean(fileName))
 	if err != nil {
 		testsuit.T.Fail(fmt.Errorf("could not read file %s: %v", fileName, err))
 	}
@@ -429,7 +430,7 @@ func GeneratePipelineRunYaml(eventType, branch string) {
 // updateAnnotation updates the specified annotation in the pull-request.yaml file
 func UpdateAnnotation(annotationKey, annotationValue string) {
 	fileName := store.GetScenarioData("fileName")
-	data, err := os.ReadFile(fileName)
+	data, err := os.ReadFile(filepath.Clean(fileName))
 	if err != nil {
 		testsuit.T.Fail(fmt.Errorf("failed to read YAML file: %v", err))
 	}

--- a/pkg/pipelines/ecosystem.go
+++ b/pkg/pipelines/ecosystem.go
@@ -22,7 +22,7 @@ func AssertTaskPresent(c *clients.Clients, namespace string, taskName string) {
 		return false, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Tasks %v Expected: Present, Actual: Not Present, Error: %v", taskName, err))
+		testsuit.T.Fail(fmt.Errorf("tasks %v Expected: Present, Actual: Not Present, Error: %v", taskName, err))
 	} else {
 		log.Printf("Task %v is present", taskName)
 	}
@@ -38,7 +38,7 @@ func AssertTaskNotPresent(c *clients.Clients, namespace string, taskName string)
 		return true, nil
 	})
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Tasks %v Expected: Not Present, Actual: Present, Error: %v", taskName, err))
+		testsuit.T.Fail(fmt.Errorf("tasks %v Expected: Not Present, Actual: Present, Error: %v", taskName, err))
 	} else {
 		log.Printf("Task %v is not present", taskName)
 	}

--- a/pkg/pipelines/helper.go
+++ b/pkg/pipelines/helper.go
@@ -33,16 +33,16 @@ func checkLabelPropagation(c *clients.Clients, namespace string, pipelineRunName
 	}
 
 	// By default, controller doesn't add any labels to Pipelines
-	for key, val := range p.ObjectMeta.Labels {
+	for key, val := range p.Labels {
 		labels[key] = val
 	}
 
 	// This label is added to every PipelineRun by the PipelineRun controller
 	labels[pipeline.PipelineLabelKey] = p.Name
-	AssertLabelsMatch(labels, pr.ObjectMeta.Labels)
+	AssertLabelsMatch(labels, pr.Labels)
 
 	// Check label propagation to TaskRuns.
-	for key, val := range pr.ObjectMeta.Labels {
+	for key, val := range pr.Labels {
 		labels[key] = val
 	}
 	// This label is added to every TaskRun by the PipelineRun controller
@@ -54,13 +54,13 @@ func checkLabelPropagation(c *clients.Clients, namespace string, pipelineRunName
 		}
 
 		// By default, controller doesn't add any labels to Tasks
-		for key, val := range task.ObjectMeta.Labels {
+		for key, val := range task.Labels {
 			labels[key] = val
 		}
 		// This label is added to TaskRuns that reference a Task by the TaskRun controller
 		labels[pipeline.TaskLabelKey] = task.Name
 	}
-	AssertLabelsMatch(labels, tr.ObjectMeta.Labels)
+	AssertLabelsMatch(labels, tr.Labels)
 
 	// PodName is "" if a retry happened and pod is deleted
 	// This label is added to every Pod by the TaskRun controller
@@ -69,7 +69,7 @@ func checkLabelPropagation(c *clients.Clients, namespace string, pipelineRunName
 		pod := GetPodForTaskRun(c, namespace, tr)
 		// This label is added to every Pod by the TaskRun controller
 		labels[pipeline.TaskRunLabelKey] = tr.Name
-		AssertLabelsMatch(labels, pod.ObjectMeta.Labels)
+		AssertLabelsMatch(labels, pod.Labels)
 	}
 }
 
@@ -89,13 +89,13 @@ func checkAnnotationPropagation(c *clients.Clients, namespace string, pipelineRu
 		testsuit.T.Errorf("failed to get pipeline for pipeline run %s \n %v", pr.Name, err)
 	}
 
-	for key, val := range p.ObjectMeta.Annotations {
+	for key, val := range p.Annotations {
 		annotations[key] = val
 	}
-	AssertAnnotationsMatch(annotations, pr.ObjectMeta.Annotations)
+	AssertAnnotationsMatch(annotations, pr.Annotations)
 
 	// Check annotation propagation to TaskRuns.
-	for key, val := range pr.ObjectMeta.Annotations {
+	for key, val := range pr.Annotations {
 		// Annotations created by Chains are created after task runs finish
 		if !strings.HasPrefix(key, "chains.tekton.dev") && !strings.HasPrefix(key, "results.tekton.dev") {
 			annotations[key] = val
@@ -106,15 +106,15 @@ func checkAnnotationPropagation(c *clients.Clients, namespace string, pipelineRu
 		if err != nil {
 			testsuit.T.Errorf("failed to get task for task run %s \n %v", tr.Name, err)
 		}
-		for key, val := range task.ObjectMeta.Annotations {
+		for key, val := range task.Annotations {
 			annotations[key] = val
 		}
 	}
-	AssertAnnotationsMatch(annotations, tr.ObjectMeta.Annotations)
+	AssertAnnotationsMatch(annotations, tr.Annotations)
 
 	// Check annotation propagation to Pods.
 	pod := GetPodForTaskRun(c, namespace, tr)
-	AssertAnnotationsMatch(annotations, pod.ObjectMeta.Annotations)
+	AssertAnnotationsMatch(annotations, pod.Annotations)
 }
 
 func GetPodForTaskRun(c *clients.Clients, namespace string, tr *v1.TaskRun) *corev1.Pod {

--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -297,7 +297,7 @@ func AssertNumberOfPipelineruns(c *clients.Clients, namespace, numberOfPr, timeo
 	})
 	if err != nil {
 		prlist, _ := c.PipelineRunClient.List(c.Ctx, metav1.ListOptions{})
-		testsuit.T.Fail(fmt.Errorf("Error: Expected %v pipelineruns but found %v pipelineruns: %s", numberOfPr, len(prlist.Items), err))
+		testsuit.T.Fail(fmt.Errorf("error: Expected %v pipelineruns but found %v pipelineruns: %s", numberOfPr, len(prlist.Items), err))
 	}
 }
 
@@ -314,7 +314,7 @@ func AssertNumberOfTaskruns(c *clients.Clients, namespace, numberOfTr, timeoutSe
 	})
 	if err != nil {
 		trlist, _ := c.TaskRunClient.List(c.Ctx, metav1.ListOptions{})
-		testsuit.T.Fail(fmt.Errorf("Error: Expected %v taskruns but found %v taskruns: %s", numberOfTr, len(trlist.Items), err))
+		testsuit.T.Fail(fmt.Errorf("error: Expected %v taskruns but found %v taskruns: %s", numberOfTr, len(trlist.Items), err))
 	}
 }
 func AssertPipelinesPresent(c *clients.Clients, namespace string) {
@@ -336,7 +336,7 @@ func AssertPipelinesPresent(c *clients.Clients, namespace string) {
 	})
 	if err != nil {
 		p, _ := pclient.List(c.Ctx, metav1.ListOptions{})
-		testsuit.T.Fail(fmt.Errorf("Expected: %v pipelines present in namespace %v, Actual: %v pipelines present in namespace %v , Error: %v", expectedNumberOfPipelines, namespace, len(p.Items), namespace, err))
+		testsuit.T.Fail(fmt.Errorf("expected: %v pipelines present in namespace %v, Actual: %v pipelines present in namespace %v , Error: %v", expectedNumberOfPipelines, namespace, len(p.Items), namespace, err))
 	}
 	log.Printf("Pipelines are present in namespace %v", namespace)
 }
@@ -353,7 +353,7 @@ func AssertPipelinesNotPresent(c *clients.Clients, namespace string) {
 	})
 	if err != nil {
 		p, _ := pclient.List(c.Ctx, metav1.ListOptions{})
-		testsuit.T.Fail(fmt.Errorf("Expected: %v number of pipelines present in namespace %v, Actual: %v number of pipelines present in namespace %v , Error: %v", 0, namespace, len(p.Items), namespace, err))
+		testsuit.T.Fail(fmt.Errorf("expected: %v number of pipelines present in namespace %v, Actual: %v number of pipelines present in namespace %v , Error: %v", 0, namespace, len(p.Items), namespace, err))
 	}
 	log.Printf("Pipelines are present in namespace %v", namespace)
 }
@@ -403,13 +403,13 @@ func GetLatestPipelinerun(c *clients.Clients, namespace string) (string, error) 
 func CheckLogVersion(c *clients.Clients, binary, namespace string) {
 	prname, err := GetLatestPipelinerun(store.Clients(), store.Namespace())
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Failed to get PipelineRun: %v", err))
+		testsuit.T.Fail(fmt.Errorf("failed to get PipelineRun: %v", err))
 		return
 	}
 	// Get PipelineRun logs
 	logsBuffer, err := getPipelinerunLogs(c, prname, namespace)
 	if err != nil {
-		testsuit.T.Fail(fmt.Errorf("Failed to get PipelineRun logs: %v", err))
+		testsuit.T.Fail(fmt.Errorf("failed to get PipelineRun logs: %v", err))
 		return
 	}
 
@@ -429,6 +429,6 @@ func CheckLogVersion(c *clients.Clients, binary, namespace string) {
 			testsuit.T.Fail(fmt.Errorf("tkn Version %s not found in logs:\n%s ", expectedVersion, logsBuffer))
 		}
 	default:
-		testsuit.T.Fail(fmt.Errorf("Unknown binary or client"))
+		testsuit.T.Fail(fmt.Errorf("unknown binary or client"))
 	}
 }

--- a/pkg/pipelines/taskrun.go
+++ b/pkg/pipelines/taskrun.go
@@ -130,16 +130,16 @@ func ValidateTaskRunLabelPropogation(c *clients.Clients, trname, namespace strin
 		testsuit.T.Errorf("failed to get task run %s in namespace %s \n %v", matched_tr, namespace, err)
 	}
 
-	for key, val := range tr.ObjectMeta.Labels {
+	for key, val := range tr.Labels {
 		labels[key] = val
 	}
 
-	AssertLabelsMatch(labels, tr.ObjectMeta.Labels)
+	AssertLabelsMatch(labels, tr.Labels)
 	if tr.Status.PodName != "" {
 		pod := GetPodForTaskRun(c, namespace, tr)
 		// This label is added to every Pod by the TaskRun controller
 		labels[pipeline.TaskRunLabelKey] = tr.Name
-		AssertLabelsMatch(labels, pod.ObjectMeta.Labels)
+		AssertLabelsMatch(labels, pod.Labels)
 		gauge.WriteMessage("Labels: \n\n %+v", createKeyValuePairs(labels))
 	}
 }

--- a/pkg/triggers/helper.go
+++ b/pkg/triggers/helper.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/getgauge-contrib/gauge-go/testsuit"
 	"github.com/openshift-pipelines/release-tests/pkg/config"
-	resource "github.com/openshift-pipelines/release-tests/pkg/config"
 	"github.com/openshift-pipelines/release-tests/pkg/store"
 )
 
@@ -40,11 +39,11 @@ func CreateHTTPClient() *http.Client {
 // CreateHTTPSClient for connection re-use
 func CreateHTTPSClient() *http.Client {
 	// Load client cert
-	cert, err := tls.LoadX509KeyPair(resource.Path("testdata/triggers/certs/server.crt"), resource.Path("testdata/triggers/certs/server.key"))
+	cert, err := tls.LoadX509KeyPair(config.Path("testdata/triggers/certs/server.crt"), config.Path("testdata/triggers/certs/server.key"))
 	if err != nil {
 		log.Fatal(err)
 	}
-	caCert, err := os.ReadFile(resource.Path("testdata/triggers/certs/ca.crt"))
+	caCert, err := os.ReadFile(config.Path("testdata/triggers/certs/ca.crt"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/triggers/triggers.go
+++ b/pkg/triggers/triggers.go
@@ -203,7 +203,7 @@ func AssertElResponse(c *clients.Clients, resp *http.Response, elname, namespace
 		EventListener: elname,
 		Namespace:     namespace,
 	}
-
+	//nolint:errcheck
 	defer resp.Body.Close()
 	var gotBody sink.Response
 	err := json.NewDecoder(resp.Body).Decode(&gotBody)
@@ -286,6 +286,7 @@ func GetRoute(elname, namespace string) string {
 		if err != nil {
 			testsuit.T.Fail(err)
 		}
+		//nolint:errcheck
 		defer file.Close()
 
 		if _, err := file.WriteString(serverCert); err != nil {

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -127,10 +127,13 @@ func Succeed(name string) ConditionAccessorFn {
 	return func(ca apis.ConditionAccessor) (bool, error) {
 		c := ca.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
-			if c.Status == corev1.ConditionTrue {
+			switch c.Status {
+			case corev1.ConditionTrue:
 				return true, nil
-			} else if c.Status == corev1.ConditionFalse {
+			case corev1.ConditionFalse:
 				return true, fmt.Errorf("%q failed", name)
+			default:
+				return false, nil
 			}
 		}
 		return false, nil
@@ -143,10 +146,13 @@ func Failed(name string) ConditionAccessorFn {
 	return func(ca apis.ConditionAccessor) (bool, error) {
 		c := ca.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
-			if c.Status == corev1.ConditionTrue {
+			switch c.Status {
+			case corev1.ConditionTrue:
 				return true, fmt.Errorf("%q succeeded", name)
-			} else if c.Status == corev1.ConditionFalse {
+			case corev1.ConditionFalse:
 				return true, nil
+			default:
+				return false, nil
 			}
 		}
 		return false, nil
@@ -159,13 +165,16 @@ func FailedWithReason(reason, name string) ConditionAccessorFn {
 	return func(ca apis.ConditionAccessor) (bool, error) {
 		c := ca.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
-			if c.Status == corev1.ConditionFalse {
+			switch c.Status {
+			case corev1.ConditionFalse:
 				if c.Reason == reason {
 					return true, nil
 				}
 				return true, fmt.Errorf("%q completed with the wrong reason, was: %s, expected: %s", name, reason, c.Reason)
-			} else if c.Status == corev1.ConditionTrue {
+			case corev1.ConditionTrue:
 				return true, fmt.Errorf("%q completed successfully, should have been failed with reason %q", name, reason)
+			default:
+				return false, nil
 			}
 		}
 		return false, nil
@@ -178,13 +187,16 @@ func FailedWithMessage(message, name string) ConditionAccessorFn {
 	return func(ca apis.ConditionAccessor) (bool, error) {
 		c := ca.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
-			if c.Status == corev1.ConditionFalse {
+			switch c.Status {
+			case corev1.ConditionFalse:
 				if strings.Contains(c.Message, message) {
 					return true, nil
 				}
 				return true, fmt.Errorf("%q completed with the wrong message: %s", name, c.Message)
-			} else if c.Status == corev1.ConditionTrue {
+			case corev1.ConditionTrue:
 				return true, fmt.Errorf("%q completed successfully, should have been failed with message %q", name, message)
+			default:
+				return false, nil
 			}
 		}
 		return false, nil

--- a/steps/cli/oc.go
+++ b/steps/cli/oc.go
@@ -269,6 +269,6 @@ var _ = gauge.Step("Copy secret <secretName> from <sourceNamespace> namespace to
 	if oc.SecretExists(secretName, sourceNamespace) {
 		oc.CopySecret(secretName, sourceNamespace, store.Namespace())
 	} else {
-		testsuit.T.Fail(fmt.Errorf("Secret %s doesn't exist in namespace %s", secretName, sourceNamespace))
+		testsuit.T.Fail(fmt.Errorf("secret %s doesn't exist in namespace %s", secretName, sourceNamespace))
 	}
 })

--- a/steps/hooks.go
+++ b/steps/hooks.go
@@ -39,7 +39,7 @@ var _ = gauge.BeforeScenario(func(exInfo *gauge_messages.ExecutionInfo) {
 	} else {
 		sa := k8s.WaitForServiceAccount(cs, namespace, "pipeline")
 		if sa == nil {
-			testsuit.T.Fail(fmt.Errorf("Service account 'pipeline' not available in namespace %s", namespace))
+			testsuit.T.Fail(fmt.Errorf("service account 'pipeline' not available in namespace %s", namespace))
 		}
 	}
 }, []string{}, testsuit.AND)
@@ -88,7 +88,7 @@ var _ = gauge.BeforeSpec(func(exInfo *gauge_messages.ExecutionInfo) {
 	}
 	log.Print("Annotating the namespaces with 'operator.tekton.dev/prune.skip=true' so that the pipelineruns should not get deleted")
 	for _, ns := range namespaces.Items {
-		if !(strings.HasPrefix(ns.Name, "openshift-") || strings.HasPrefix(ns.Name, "kube-") || ns.Name == "default") {
+		if !strings.HasPrefix(ns.Name, "openshift-") && !strings.HasPrefix(ns.Name, "kube-") && ns.Name != "default" {
 			oc.AnnotateNamespaceIgnoreErrors(ns.Name, "operator.tekton.dev/prune.skip=true")
 		}
 	}


### PR DESCRIPTION
List of 70+ violated rules
* QF1001: could apply De Morgan's law (staticcheck)
* QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
* ST1005: error strings should not be capitalized (staticcheck)
* ST1019: package "github.com/openshift-pipelines/release-tests/pkg/config" is being imported more than once (staticcheck)
* ST1023: should omit type string from declaration; it will be inferred from the right-hand side (staticcheck)
* Error return value of `file.Close` is not checked (errcheck)
* Error return value of `os.Setenv` is not checked (errcheck)
* Error return value of `resp.Body.Close` is not checked (errcheck)
* G301: Expect directory permissions to be 0750 or less (gosec)
* G304: Potential file inclusion via variable (gosec)