### PR TITLE
Fix for upgrade path for chains & results sts 

### DIFF
--- a/specs/olm.spec
+++ b/specs/olm.spec
@@ -23,12 +23,12 @@ Steps:
   * Configure the bundles resolver
   * Enable console plugin
   * Enable statefulset in tektonconfig
-  * Enable statefulset for "chains" in tektonconfig
-  * Enable statefulset for "results" in tektonconfig
   * Validate triggers deployment
   * Validate PAC deployment
   * Enable generateSigningSecret for Tekton Chains in TektonConfig
   * Validate hub deployment
+  * Enable statefulset for "chains" in tektonconfig
+  * Enable statefulset for "results" in tektonconfig
   * Validate "tekton-pipelines-controller" statefulset deployment
   * Validate "tekton-pipelines-remote-resolvers" statefulset deployment
   * Validate "tekton-chains-controller" statefulset deployment


### PR DESCRIPTION
Earlier facing the issue when performing upgrade flow for enabling statefulset for chains & results with the below error
`Command:  oc patch tektonconfig config -p {"spec":{"chain":{"performance":{"disable-ha":false,"statefulset-ordinals":true,"replicas":2,"buckets":2}}}} --type=merge
ExitCode: 1
Error:    exit status 1
Stdout:   
Stderr:   Error from server (BadRequest): admission webhook "webhook.operator.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "performance"`

Reorganized the steps in olm.spec 
<img width="1622" height="973" alt="image" src="https://github.com/user-attachments/assets/3a96f065-830d-4a20-a00f-bdc6e45e6fd4" />
