### PR TITLE
 add new buildah-ns task to release tests

### DIFF
--- a/specs/ecosystem/ecosystem.spec
+++ b/specs/ecosystem/ecosystem.spec
@@ -42,6 +42,25 @@ Steps:
       |----|------------------------|----------|
       |1   |buildah-disconnected-run|successful|
 
+## buildah-ns pipelinerun: PIPELINES-29-TC20
+Tags: e2e, ecosystem, tasks, non-admin, buildah-ns, sanity
+Component: Pipelines
+Level: Integration
+Type: Functional
+Importance: Critical
+
+Steps:
+  * Create
+      |S.NO|resource_dir                                     |
+      |----|-------------------------------------------------|
+      |1   |testdata/ecosystem/pipelines/buildah-ns.yaml        |
+      |2   |testdata/pvc/pvc.yaml                            |
+      |3   |testdata/ecosystem/pipelineruns/buildah-ns.yaml     |
+  * Verify pipelinerun
+      |S.NO|pipeline_run_name|status    |
+      |----|-----------------|----------|
+      |1   |buildah-ns-run      |successful|
+
 ## git-cli pipelinerun: PIPELINES-29-TC03
 Tags: e2e, ecosystem, tasks, non-admin, git-cli
 Component: Pipelines

--- a/testdata/ecosystem/pipelineruns/buildah-ns.yaml
+++ b/testdata/ecosystem/pipelineruns/buildah-ns.yaml
@@ -1,0 +1,13 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: buildah-ns-run
+spec:
+  pipelineRef:
+    name: buildah-ns-pipeline
+  timeouts: 
+    pipeline: 10m
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: shared-pvc

--- a/testdata/ecosystem/pipelines/buildah-ns.yaml
+++ b/testdata/ecosystem/pipelines/buildah-ns.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: buildah-ns-pipeline
+spec:
+  params:
+    - name: REVISION
+      default: fedora-38
+    - name: SUBDIR
+      description: where to clone the git repo
+      default: buildah
+  workspaces:
+    - name: source
+  tasks:
+    - name: clone-git-repo
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: namespace
+            value: openshift-pipelines
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: URL
+          value: https://github.com/ppitonak/nocode
+        - name: SUBDIRECTORY
+          value: $(params.SUBDIR)
+        - name: DELETE_EXISTING
+          value: "true"
+        - name: REVISION
+          value: $(params.REVISION)
+    - name: run-buildah
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: buildah-ns
+          - name: namespace
+            value: openshift-pipelines
+      runAfter:
+        - clone-git-repo
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.SUBDIR)
+        - name: CONTEXT
+          value: $(params.SUBDIR)
+        - name: DOCKERFILE
+          value: $(params.SUBDIR)/Dockerfile
+        - name: TLSVERIFY
+          value: "true"


### PR DESCRIPTION
<img width="1707" height="956" alt="Screenshot 2025-10-09 at 12 17 48 PM" src="https://github.com/user-attachments/assets/2a1e843f-eb15-4774-b8ce-02c840c08631" />
 `# Verify Ecosystem Tasks E2E spec
  ## buildah-ns pipelinerun: PIPELINES-29-TC20	
2025/10/09 12:16:20 output: Now using project "releasetest-qs2qk" on server "https://api.kzses-ejv45-77d.02p0.p3.openshiftapps.com:443".
You can add applications to this project with the 'new-app' command. For example, try:
oc new-app rails-postgresql-example
to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:
kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname
2025/10/09 12:16:28 Waiting for operator to be up and running....
2025/10/09 12:16:29 Operator is up
      * Validate Operator should be installed	 ...[PASS]
2025/10/09 12:16:30 output: pipeline.tekton.dev/buildah-ns-pipeline created
2025/10/09 12:16:31 output: persistentvolumeclaim/shared-pvc created
2025/10/09 12:16:32 output: pipelinerun.tekton.dev/buildah-ns-run created
      * Create 
      
         |S.NO|resource_dir                                   |
         |----|-----------------------------------------------|
         |1   |testdata/ecosystem/pipelines/buildah-ns.yaml   |
         |2   |testdata/pvc/pvc.yaml                          |
         |3   |testdata/ecosystem/pipelineruns/buildah-ns.yaml|	 ...[PASS]
2025/10/09 12:16:33 validating pipeline run buildah-ns-run for success state...
2025/10/09 12:17:38 pipelineRun: buildah-ns-run is successful under namespace : releasetest-qs2qk
      * Verify pipelinerun 
      
         |S.NO|pipeline_run_name|status    |
         |----|-----------------|----------|
         |1   |buildah-ns-run   |successful|	 ...[PASS]
2025/10/09 12:19:08 output: project.project.openshift.io "releasetest-qs2qk" deleted

Transformed SuiteResult to report structure
Successfully generated html-report to => /Users/jayesh/project/release-tests/reports/html-report/index.html

Done generating HTML report using theme from /Users/jayesh/.gauge/plugins/html-report/4.3.3/themes/default
Successfully generated xml-report to => /Users/jayesh/project/release-tests/reports/xml-report

Sending kill message to Html Report plugin.
Sending kill message to Xml Report plugin.
Sending kill message to runner.
ok  	command-line-arguments	171.104s
Runner with PID:38779 has exited
Specifications:	1 executed	1 passed	0 failed	0 skipped
Scenarios:	1 executed	1 passed	0 failed	0 skipped

`